### PR TITLE
Enable keyboard navigation via tab

### DIFF
--- a/source/App.svelte
+++ b/source/App.svelte
@@ -29,6 +29,13 @@
 		showInfoMessage = false;
 	}
 
+	function keyboardNavigationHandler(event) {
+		if (event.key === 'Tab') {
+			document.body.classList.add('keyboard-navigation');
+			showExtras = true;
+		}
+	}
+
 	function toggleAll(enable) {
 		const affectedExtensions = extensions.filter(extension => enable !== extension.enabled);
 
@@ -70,6 +77,8 @@
 		event.preventDefault();
 	}
 </script>
+
+<svelte:window on:keydown={keyboardNavigationHandler}/>
 
 <main>
 	{#if showInfoMessage}

--- a/source/style.css
+++ b/source/style.css
@@ -44,7 +44,9 @@ button {
 }
 
 a:hover,
-button:hover {
+.keyboard-navigation a:focus,
+button:hover,
+.keyboard-navigation button:focus {
 	background-color: #ecf0f1;
 	cursor: pointer;
 }
@@ -125,7 +127,8 @@ button:hover {
 	margin-inline-end: var(--margin);
 }
 
-.ext:hover > * {
+.ext:hover > *,
+.keyboard-navigation .ext:focus-within > * {
 	opacity: 1;
 }
 
@@ -148,7 +151,9 @@ button:hover {
 	}
 
 	a:hover,
-	button:hover {
+	.keyboard-navigation a:focus,
+	button:hover,
+	.keyboard-navigation button:focus {
 		background-color: #c4d7dc38;
 	}
 


### PR DESCRIPTION
Closes #21 

When <kbd>tab</kbd> is pressed, now everything can be focused and hidden buttons also appear.

Extensions can be toggled with <kbd>enter</kbd> or <kbd>space</kbd>. Links can be visited with <kbd>enter</kbd>

![tab](https://user-images.githubusercontent.com/1402241/79644372-d8cca300-81a8-11ea-834d-b5679861e0cb.gif)
