### PR TITLE
fix context menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2810,6 +2810,12 @@
 			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
 			"dev": true
 		},
+		"compare-versions": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npm.taobao.org/compare-versions/download/compare-versions-3.6.0.tgz?cache=0&sync_timestamp=1581641011823&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcompare-versions%2Fdownload%2Fcompare-versions-3.6.0.tgz",
+			"integrity": "sha1-GlaJkTaF5ah2N7jT/8p1UU7EHWI=",
+			"dev": true
+		},
 		"component-emitter": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -5206,6 +5212,15 @@
 				"locate-path": "^2.0.0"
 			}
 		},
+		"find-versions": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npm.taobao.org/find-versions/download/find-versions-3.2.0.tgz",
+			"integrity": "sha1-ECl/mAMKeGgpaBaQVF72We0dJU4=",
+			"dev": true,
+			"requires": {
+				"semver-regex": "^2.0.0"
+			}
+		},
 		"firefox-profile": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/firefox-profile/-/firefox-profile-1.3.0.tgz",
@@ -5838,6 +5853,76 @@
 			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
 			"integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
 			"dev": true
+		},
+		"husky": {
+			"version": "4.2.5",
+			"resolved": "https://registry.npm.taobao.org/husky/download/husky-4.2.5.tgz?cache=0&sync_timestamp=1586469908461&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fhusky%2Fdownload%2Fhusky-4.2.5.tgz",
+			"integrity": "sha1-K092Imc6cVefkB2Yhe1Eg5S1+jY=",
+			"dev": true,
+			"requires": {
+				"chalk": "^4.0.0",
+				"ci-info": "^2.0.0",
+				"compare-versions": "^3.6.0",
+				"cosmiconfig": "^6.0.0",
+				"find-versions": "^3.2.0",
+				"opencollective-postinstall": "^2.0.2",
+				"pkg-dir": "^4.2.0",
+				"please-upgrade-node": "^3.2.0",
+				"slash": "^3.0.0",
+				"which-pm-runs": "^1.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-4.2.1.tgz",
+					"integrity": "sha1-kK51xCTQCNJiTFvynq0xd+v881k=",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npm.taobao.org/chalk/download/chalk-4.1.0.tgz",
+					"integrity": "sha1-ThSHCmGNni7dl92DRf2dncMVZGo=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-2.0.1.tgz",
+					"integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npm.taobao.org/color-name/download/color-name-1.1.4.tgz",
+					"integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-4.0.0.tgz",
+					"integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-7.1.0.tgz",
+					"integrity": "sha1-aOMlkd9z4lrRxLSRCKLsUHliv9E=",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
 		},
 		"iconv-lite": {
 			"version": "0.4.24",
@@ -7808,6 +7893,12 @@
 				}
 			}
 		},
+		"opencollective-postinstall": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npm.taobao.org/opencollective-postinstall/download/opencollective-postinstall-2.0.3.tgz?cache=0&sync_timestamp=1590746981761&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fopencollective-postinstall%2Fdownload%2Fopencollective-postinstall-2.0.3.tgz",
+			"integrity": "sha1-eg//l49tv6TQBiOPusmO1BmMMlk=",
+			"dev": true
+		},
 		"optionator": {
 			"version": "0.8.3",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
@@ -8272,6 +8363,15 @@
 			"dev": true,
 			"requires": {
 				"find-up": "^2.1.0"
+			}
+		},
+		"please-upgrade-node": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npm.taobao.org/please-upgrade-node/download/please-upgrade-node-3.2.0.tgz",
+			"integrity": "sha1-rt3T+ZTJM+StmLmdmlVu+g4v6UI=",
+			"dev": true,
+			"requires": {
+				"semver-compare": "^1.0.0"
 			}
 		},
 		"plur": {
@@ -9254,6 +9354,12 @@
 			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 			"dev": true
 		},
+		"semver-compare": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npm.taobao.org/semver-compare/download/semver-compare-1.0.0.tgz",
+			"integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
+			"dev": true
+		},
 		"semver-diff": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-3.1.1.tgz",
@@ -9262,6 +9368,12 @@
 			"requires": {
 				"semver": "^6.3.0"
 			}
+		},
+		"semver-regex": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npm.taobao.org/semver-regex/download/semver-regex-2.0.0.tgz",
+			"integrity": "sha1-qTwsWERTmncCMzeRB7OMe0rJ0zg=",
+			"dev": true
 		},
 		"set-blocking": {
 			"version": "2.0.0",
@@ -12032,6 +12144,12 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
 			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+			"dev": true
+		},
+		"which-pm-runs": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npm.taobao.org/which-pm-runs/download/which-pm-runs-1.0.0.tgz",
+			"integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
 			"dev": true
 		},
 		"widest-line": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
 		"dot-json": "^1.2.0",
 		"eslint": "^6.8.0",
 		"eslint-plugin-svelte3": "^2.7.3",
+		"husky": "^4.2.5",
 		"npm-run-all": "^4.1.5",
 		"rollup": "^2.6.1",
 		"rollup-plugin-copy-glob": "^0.3.1",
@@ -77,5 +78,10 @@
 		"svelte": "^3.20.1",
 		"web-ext": "^4.1.0",
 		"xo": "^0.29.1"
+	},
+	"husky":{
+		"hooks":{
+			"pre-commit": "npm run fix"
+		}
 	}
 }

--- a/source/App.svelte
+++ b/source/App.svelte
@@ -71,12 +71,12 @@
 		});
 	});
 
-	// Show extra buttons on right click on the name
+	// Toggle extra buttons on right click on the name
 	let onContextMenu;
-	$: onContextMenu = showExtras ? () => {} : (event => {
-		showExtras = true;
+	$: onContextMenu = event => {
+		showExtras = !showExtras;
 		event.preventDefault();
-	});
+	};
 </script>
 
 <svelte:window on:keydown={keyboardNavigationHandler}/>

--- a/source/Extension.svelte
+++ b/source/Extension.svelte
@@ -49,9 +49,7 @@
 	<button type="button" class="ext-name" on:click={toggleExtension} on:contextmenu>
 		<img alt="" src={getIcon(icons, 16)}>{name}
 	</button>
-
-	{#if enabled}
-		{#if optionsUrl}
+		{#if  showExtras || (optionsUrl && enabled)}
 			<a href='chrome://extensions/?options={id}' title={getI18N('gotoOpt')} on:click={openInTab}>
 				<img src="icons/options.svg" alt="">
 			</a>
@@ -69,5 +67,4 @@
 				<img src="icons/bin.svg" alt="">
 			</button>
 		{/if}
-	{/if}
 </li>

--- a/source/lib/open-in-tab.js
+++ b/source/lib/open-in-tab.js
@@ -1,5 +1,5 @@
 /** Required for chrome:// links */
 export default function openInTab(event) {
-	browser.tabs.create({url: event.target.href});
+	browser.tabs.create({url: event.currentTarget.href});
 	event.preventDefault();
 }


### PR DESCRIPTION
fix several issues:
- the context menu is not working correctly, currently it only shows extra icons for enabled extensions when user right click on the popup. if I want to uninstall or check a disabled extension in Chrome web store, I have to enable it first. showing all possible options is default behavior, and I think it should not be changed.
- the options url and chrome web store url is not workin in current version, fixed
- added pre commit hooks to run`fix` before commit