### PR TITLE
 fix options icon and url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9085,7 +9085,7 @@
 		},
 		"require-relative": {
 			"version": "0.8.7",
-			"resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
+			"resolved": "https://registry.npm.taobao.org/require-relative/download/require-relative-0.8.7.tgz",
 			"integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
 			"dev": true
 		},
@@ -9257,9 +9257,9 @@
 			}
 		},
 		"rollup-plugin-svelte": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-svelte/-/rollup-plugin-svelte-5.2.1.tgz",
-			"integrity": "sha512-wc93cN66sRpX6uFljVFqvWT6NU3V5ab/uLXKt2UiARuexFU/ctolzkmdXM7WM5iKdTX9scToS9sabJTJV4DUMA==",
+			"version": "6.1.1",
+			"resolved": "https://registry.npm.taobao.org/rollup-plugin-svelte/download/rollup-plugin-svelte-6.1.1.tgz",
+			"integrity": "sha1-ZjYs8FAPt6hIKD688Z0ommDvCHE=",
 			"dev": true,
 			"requires": {
 				"require-relative": "^0.8.7",
@@ -9269,8 +9269,8 @@
 		},
 		"rollup-pluginutils": {
 			"version": "2.8.2",
-			"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
-			"integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+			"resolved": "https://registry.npm.taobao.org/rollup-pluginutils/download/rollup-pluginutils-2.8.2.tgz",
+			"integrity": "sha1-cvKvB0i1kjZNvTOJ5gDlqURKNR4=",
 			"dev": true,
 			"requires": {
 				"estree-walker": "^0.6.1"
@@ -9278,8 +9278,8 @@
 			"dependencies": {
 				"estree-walker": {
 					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-					"integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+					"resolved": "https://registry.npm.taobao.org/estree-walker/download/estree-walker-0.6.1.tgz?cache=0&sync_timestamp=1607445422409&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Festree-walker%2Fdownload%2Festree-walker-0.6.1.tgz",
+					"integrity": "sha1-UwSRQ/QMbrkYsjZx0f4yGfOhs2I=",
 					"dev": true
 				}
 			}
@@ -9742,8 +9742,8 @@
 		},
 		"sourcemap-codec": {
 			"version": "1.4.8",
-			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+			"resolved": "https://registry.npm.taobao.org/sourcemap-codec/download/sourcemap-codec-1.4.8.tgz",
+			"integrity": "sha1-6oBL2UhXQC5pktBaOO8a41qatMQ=",
 			"dev": true
 		},
 		"spawn-sync": {

--- a/package.json
+++ b/package.json
@@ -72,15 +72,15 @@
 		"rollup": "^2.6.1",
 		"rollup-plugin-copy-glob": "^0.3.1",
 		"rollup-plugin-livereload": "^1.2.0",
-		"rollup-plugin-svelte": "^5.2.1",
+		"rollup-plugin-svelte": "^6.1.1",
 		"stylelint": "^13.3.2",
 		"stylelint-config-xo": "^0.16.1",
 		"svelte": "^3.20.1",
 		"web-ext": "^4.1.0",
 		"xo": "^0.29.1"
 	},
-	"husky":{
-		"hooks":{
+	"husky": {
+		"hooks": {
 			"pre-commit": "npm run fix"
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -78,10 +78,5 @@
 		"svelte": "^3.20.1",
 		"web-ext": "^4.1.0",
 		"xo": "^0.29.1"
-	},
-	"husky": {
-		"hooks": {
-			"pre-commit": "npm run fix"
-		}
 	}
 }

--- a/source/Extension.svelte
+++ b/source/Extension.svelte
@@ -41,7 +41,7 @@
 
 		// Fallback icon
 		return 'icons/puzzle.svg';
-  }
+ }
 </script>
 
 <li class:disabled={!enabled} class="ext type-{installType}">

--- a/source/Extension.svelte
+++ b/source/Extension.svelte
@@ -9,8 +9,7 @@
 	export let optionsUrl;
 	export let icons;
 	export let showExtras;
-	export let undoStack;
-
+  export let undoStack;
 	const getI18N = browser.i18n.getMessage;
 	const url = installType === 'normal' ? `https://chrome.google.com/webstore/detail/${id}` : homepageUrl;
 
@@ -42,15 +41,15 @@
 
 		// Fallback icon
 		return 'icons/puzzle.svg';
-	}
+  }
 </script>
 
 <li class:disabled={!enabled} class="ext type-{installType}">
 	<button type="button" class="ext-name" on:click={toggleExtension} on:contextmenu>
 		<img alt="" src={getIcon(icons, 16)}>{name}
 	</button>
-		{#if  showExtras || (optionsUrl && enabled)}
-			<a href='chrome://extensions/?options={id}' title={getI18N('gotoOpt')} on:click={openInTab}>
+		{#if optionsUrl && enabled}
+			<a href="{optionsUrl}" title={getI18N('gotoOpt')} on:click={openInTab}>
 				<img src="icons/options.svg" alt="">
 			</a>
 		{/if}


### PR DESCRIPTION
- currently, it will show options icon even if an extension has no options page 
- since some extension's options page does not fit well in `options_ui` mode (`chrome://extensions/?options=`), so change it to open in normal options page mode (`chrome-extension://{ID}/options.html`)

<img width="1179" alt="Screen Shot 2020-12-24 at 16 26 55" src="https://user-images.githubusercontent.com/3389447/103074665-11106500-4605-11eb-9438-b8b361b9d2f4.png">
