### PR TITLE
Don’t show Options button on disabled extensions

### DIFF
--- a/source/Extension.svelte
+++ b/source/Extension.svelte
@@ -49,8 +49,8 @@
 	<button type="button" class="ext-name" on:click={toggleExtension} on:contextmenu>
 		<img alt="" src={getIcon(icons, 16)}>{name}
 	</button>
-		{#if  showExtras || (optionsUrl && enabled)}
-			<a href='chrome://extensions/?options={id}' title={getI18N('gotoOpt')} on:click={openInTab}>
+		{#if optionsUrl && enabled}
+			<a href={optionsUrl} title={getI18N('gotoOpt')} on:click={openInTab}>
 				<img src="icons/options.svg" alt="">
 			</a>
 		{/if}


### PR DESCRIPTION
- currently, it will show options icon even if an extension has no options page. fixed to only show when an extension has options page and enabled (it won't open if it's not enabled)
- since some extension's options page does not fit well in options_ui mode (chrome://extensions/?options=), so change it to open in normal options page mode (chrome-extension://{ID}/options.html). Make it to open default `options` view.
A broken options page sample: 
<img width="1179" alt="Screen Shot 2020-12-24 at 16 26 55" src="https://user-images.githubusercontent.com/3389447/103080441-ceed2080-4610-11eb-8b95-2e0fec938a18.png">
