### PR TITLE
remove wrong hotkey on Ubuntu, fix undo style

### DIFF
--- a/source/App.svelte
+++ b/source/App.svelte
@@ -95,7 +95,7 @@
 	{#if showInfoMessage}
 		<p>
 			{@html getI18N('undoInfoMsg')}
-			<a href="#hide" on:click={hideInfoMessage}>{getI18N('hideInfoMsg')}</a>
+			<a class="hide-action" href="#hide" on:click={hideInfoMessage}>{getI18N('hideInfoMsg')}</a>
 		</p>
 	{/if}
 	<!-- svelte-ignore a11y-autofocus -->

--- a/source/_locales/en/messages.json
+++ b/source/_locales/en/messages.json
@@ -30,7 +30,7 @@
 		"message": "Search by name…"
 	},
 	"undoInfoMsg": {
-		"message": "You can undo and redo your last action until you close this popup. Press <kbd>ctrl+z</kbd> on Windows and <kbd>cmd+z</kbd> on macOS, <kbd>super+z</kbd> on Ubuntu."
+		"message": "You can undo and redo your last action until you close this popup. Press <kbd>ctrl+z</kbd> on Windows or Ubuntu,  and <kbd>cmd+z</kbd> on macOS."
 	},
 	"uninstall": {
 		"message": "Uninstall"

--- a/source/_locales/tr/messages.json
+++ b/source/_locales/tr/messages.json
@@ -40,7 +40,7 @@
 		"hash": "1220702106584c8c90c0f41c486a3e0b"
 	},
 	"undoInfoMsg": {
-		"message": "Bu pencere kapanıncaya kadar son işleminizi geri ya da ileri alabilirsiniz. Windows’ta <kbd>ctrl+z</kbd>’ye, macOS’te <kbd>cmd+z</kbd>’ye ve Ubuntu’da <kbd>super+z</kbd>’ye basın.",
+		"message": "Bu pencere kapanıncaya kadar son işleminizi geri ya da ileri alabilirsiniz. Windows’ta <kbd>ctrl+z</kbd>’ye, macOS’te <kbd>cmd+z</kbd>’ye.",
 		"hash": "4105b6ebe6d3c7badf1a2bf9d425ddbb"
 	},
 	"uninstall": {

--- a/source/_locales/zh_CN/messages.json
+++ b/source/_locales/zh_CN/messages.json
@@ -18,13 +18,13 @@
 		"message": "打开设置页面"
 	},
 	"hideInfoMsg": {
-		"message": "知道了"
+		"message": "隐藏此信息"
 	},
 	"searchTxt": {
 		"message": "查找扩展"
 	},
 	"undoInfoMsg": {
-		"message": "在关闭这个窗口前你可以撤销你的操作。 <br>在Windows中按 <kbd>ctrl+z</kbd> macOS中按<kbd>cmd+z</kbd>Linux中按<kbd>super+z</kbd>。"
+		"message": "在关闭这个窗口前你可以撤销你的操作。 在 Windows 或 Ubuntu 中按 <kbd>Ctrl+Z</kbd>, macOS 中按<kbd>CMD+Z</kbd>."
 	},
 	"uninstall": {
 		"message": "卸载这个扩展"

--- a/source/_locales/zh_TW/messages.json
+++ b/source/_locales/zh_TW/messages.json
@@ -40,7 +40,7 @@
 		"hash": "1220702106584c8c90c0f41c486a3e0b"
 	},
 	"undoInfoMsg": {
-		"message": "在關閉這個窗口前你可以撤銷你的操作。 <br>在Windows中按<kbd>ctrl+z</kbd>macOS中按<kbd>cmd+z</kbd>Linux中按<kbd>super+z</kbd>。",
+		"message": "在關閉這個窗口前你可以撤銷你的操作。 <br>在 Windows 或 Ubuntu 中按<kbd>ctrl+z</kbd>, macOS 中按<kbd>cmd+z</kbd>。",
 		"hash": "4105b6ebe6d3c7badf1a2bf9d425ddbb"
 	},
 	"uninstall": {

--- a/source/style.css
+++ b/source/style.css
@@ -68,7 +68,7 @@ button:hover,
 * HIDE MESSAGE
 */
 
-.hide-action{
+.hide-action {
 	border-bottom: 1px #2b2c2c dotted;
 }
 

--- a/source/style.css
+++ b/source/style.css
@@ -65,6 +65,14 @@ button:hover,
 }
 
 /**
+* HIDE MESSAGE
+*/
+
+.hide-action{
+	border-bottom: 1px #2b2c2c dotted;
+}
+
+/**
  * LIST
  */
 #ext-list {


### PR DESCRIPTION
Summary:
- Remove wrong hotkey text about linux 
- Adjust Chinese sentences. 
- Make `Hide this` looks like a clickable element.


The undo hotkey is still `Ctrl+Z` on Ubuntu, and we barely have linux users, so remove it to keep the text short.

I got several complaints from Chinese users that the undo message on the top looks bad in 3 lines.

Also, the `Hide this` action looks confusing since it has the same style as the long message, some people even don't know it's clickable. so adding an underline to make it obvious.

en before: 
<img width="269" alt="en_before" src="https://user-images.githubusercontent.com/3389447/193845574-a188ed7c-7926-4c16-98a5-02397df3fc17.png">
en after:
<img width="269" alt="en_after" src="https://user-images.githubusercontent.com/3389447/193845589-4668bde8-1a82-47c5-bb39-62862f1075fc.png">

zh before:
<img width="269" alt="zh_before" src="https://user-images.githubusercontent.com/3389447/193845611-616a74d7-9a99-4513-900c-283311e7c56a.png">
zh after
<img width="269" alt="zh_after" src="https://user-images.githubusercontent.com/3389447/193845620-bb90d9e7-7d1c-431c-95ec-623bbe9d49cc.png">
