### PR TITLE
Move list focus with arrow keys ⬆️⬇️

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
 			"prettier"
 		],
 		"rules": {
-			"no-new": "off"
+			"no-new": "off",
+			"no-bitwise": "off"
 		},
 		"overrides": [
 			{

--- a/source/App.svelte
+++ b/source/App.svelte
@@ -38,6 +38,7 @@
 	}
 
 	function keyboardNavigationHandler(event) {
+		// eslint-disable-next-line unicorn/prefer-switch -- Unreadable
 		if (event.key === 'Tab') {
 			showExtras = true;
 		} else if (event.key === 'ArrowDown') {

--- a/source/App.svelte
+++ b/source/App.svelte
@@ -4,6 +4,7 @@
 	import Extension from './Extension.svelte';
 	import openInTab from './lib/open-in-tab.js';
 	import UndoStack from './lib/undo-stack.js';
+	import {focusNext, focusPrevious} from './lib/focus-next.js';
 
 	const getI18N = chrome.i18n.getMessage;
 	const undoStack = new UndoStack(window);
@@ -38,9 +39,18 @@
 
 	function keyboardNavigationHandler(event) {
 		if (event.key === 'Tab') {
-			document.body.classList.add('keyboard-navigation');
 			showExtras = true;
+		} else if (event.key === 'ArrowDown') {
+			focusNext('.ext-name, [type="search"]');
+			event.preventDefault();
+		} else if (event.key === 'ArrowUp') {
+			focusPrevious('.ext-name, [type="search"]');
+			event.preventDefault();
+		} else {
+			return
 		}
+
+		document.body.classList.add('keyboard-navigation');
 	}
 
 	function toggleAll(enable) {

--- a/source/lib/focus-next.js
+++ b/source/lib/focus-next.js
@@ -1,0 +1,29 @@
+export function focusNext(selector) {
+	const {activeElement} = document;
+	const items = [...document.querySelectorAll(selector)];
+	for (const item of items) {
+		const position = activeElement.compareDocumentPosition(item);
+		// eslint-disable-next-line no-bitwise -- https://developer.mozilla.org/en-US/docs/Web/API/Node/compareDocumentPosition
+		if (position & Node.DOCUMENT_POSITION_FOLLOWING) {
+			item.focus();
+			return;
+		}
+	}
+
+	items.at(0).focus();
+}
+
+export function focusPrevious(selector) {
+	const {activeElement} = document;
+	const items = [...document.querySelectorAll(selector)].reverse();
+	for (const item of items) {
+		const position = activeElement.compareDocumentPosition(item);
+		// eslint-disable-next-line no-bitwise -- https://developer.mozilla.org/en-US/docs/Web/API/Node/compareDocumentPosition
+		if (position & Node.DOCUMENT_POSITION_PRECEDING) {
+			item.focus();
+			return;
+		}
+	}
+
+	items.at(0).focus();
+}

--- a/source/lib/focus-next.js
+++ b/source/lib/focus-next.js
@@ -1,10 +1,18 @@
-export function focusNext(selector) {
+function focus(selector, next) {
 	const {activeElement} = document;
 	const items = [...document.querySelectorAll(selector)];
+	if (!next) {
+		items.reverse();
+	}
+
 	for (const item of items) {
 		const position = activeElement.compareDocumentPosition(item);
-		// eslint-disable-next-line no-bitwise -- https://developer.mozilla.org/en-US/docs/Web/API/Node/compareDocumentPosition
-		if (position & Node.DOCUMENT_POSITION_FOLLOWING) {
+		if (
+			position &
+			(next
+				? Node.DOCUMENT_POSITION_FOLLOWING
+				: Node.DOCUMENT_POSITION_PRECEDING)
+		) {
 			item.focus();
 			return;
 		}
@@ -13,17 +21,10 @@ export function focusNext(selector) {
 	items.at(0).focus();
 }
 
-export function focusPrevious(selector) {
-	const {activeElement} = document;
-	const items = [...document.querySelectorAll(selector)].reverse();
-	for (const item of items) {
-		const position = activeElement.compareDocumentPosition(item);
-		// eslint-disable-next-line no-bitwise -- https://developer.mozilla.org/en-US/docs/Web/API/Node/compareDocumentPosition
-		if (position & Node.DOCUMENT_POSITION_PRECEDING) {
-			item.focus();
-			return;
-		}
-	}
+export function focusNext(selector) {
+	focus(selector, true);
+}
 
-	items.at(0).focus();
+export function focusPrevious(selector) {
+	focus(selector, false);
 }


### PR DESCRIPTION
Finally thought of an easy way to handle this.

## Demo

![gif](https://user-images.githubusercontent.com/1402241/194477704-acc0cad3-6e14-4ef3-a93a-243de4dde28a.gif)

## Shortcomings

- We can't easily keep the focus on the field _and_ allow selection via up/down because the `space` key would conflict between toggling an extension and filtering the list

## Related

- https://github.com/hankxdev/one-click-extensions-manager/issues/21
- https://github.com/hankxdev/one-click-extensions-manager/pull/46