### PR TITLE
Update minimum Chrome version

### DIFF
--- a/source/manifest.json
+++ b/source/manifest.json
@@ -6,7 +6,7 @@
 	"homepage_url": "https://github.com/hankxdev/one-click-extensions-manager",
 	"default_locale": "en",
 	"permissions": ["management"],
-	"minimum_chrome_version": "74",
+	"minimum_chrome_version": "110",
 	"icons": {
 		"16": "logo.png",
 		"128": "logo.png"


### PR DESCRIPTION
Latest deployment error:

```
{
15
Error: PKG_MANIFEST_PARSE_ERROR
16
  kind: 'chromewebstore#item',
17
The minimum Chrome version of 74 does not meet the minimum requirement to be published. To be published, a manifest V3 item must require at least Chrome version 88.
18
  id: '***',
19
  uploadState: 'FAILURE',
20
  itemError: [
21
    {
22
      error_code: 'PKG_MANIFEST_PARSE_ERROR',
23
      error_detail: 'The minimum Chrome version of 74 does not meet the minimum requirement to be published. To be published, a manifest V3 item must require at least Chrome version 88.'
24
    }
25
  ]
26
}
```