### PR TITLE
Keep only one window/tab open

### DIFF
--- a/source/main.js
+++ b/source/main.js
@@ -10,3 +10,10 @@ document.body.dataset.type = type;
 if (type === 'window') {
 	fitWindow();
 }
+
+chrome.runtime.sendMessage('thisTownIsTooSmallForTheTwoOfUs');
+chrome.runtime.onMessage.addListener((message) => {
+	if (message === 'thisTownIsTooSmallForTheTwoOfUs') {
+		window.close()
+	}
+});


### PR DESCRIPTION
The problem described in #105 is actually easy to resolve: just message other contexts to close them.

https://user-images.githubusercontent.com/1402241/235730779-aa1ab575-a4b5-4eb4-b750-aa65f3fd762b.mov

Ideally I'd just message any open windows to focus them _before_ opening a new one… but that doesn't seem to work (`onMessage -> self.focus()`)