### PR TITLE
Exclude linting from pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npm run fix
 npm run format


### PR DESCRIPTION
Pre-commit hooks are good for formatting, but eslint is too slow and troublesome to be included