### PR TITLE
Disable spurious hover state

### DIFF
--- a/source/style.css
+++ b/source/style.css
@@ -152,7 +152,7 @@ button:hover,
 	margin-inline-end: var(--margin);
 }
 
-/* Don't use .ext:hover */
+/* Don't use .ext:hover https://github.com/hankxdev/one-click-extensions-manager/pull/109 */
 .ext:has(:hover) > *,
 .keyboard-navigation .ext:focus-within > * {
 	opacity: 100%;

--- a/source/style.css
+++ b/source/style.css
@@ -152,7 +152,8 @@ button:hover,
 	margin-inline-end: var(--margin);
 }
 
-.ext:hover > *,
+/* Don't use .ext:hover */
+.ext:has(:hover) > *,
 .keyboard-navigation .ext:focus-within > * {
 	opacity: 100%;
 }


### PR DESCRIPTION
The border triggers a extra hover state on a non-clickable area:

![](https://github.com/hankxdev/one-click-extensions-manager/assets/1402241/2e32bd06-bee3-4ac0-a87a-a87ea2c4c622)
