### PR TITLE
Allow native context menus when the buttons are visible

### DIFF
--- a/source/App.svelte
+++ b/source/App.svelte
@@ -103,10 +103,13 @@
 	});
 
 	// Toggle extra buttons on right click on the name
+	// After the first click, allow the native context menu
 	let onContextMenu;
 	$: onContextMenu = event => {
-		showExtras = !showExtras;
-		event.preventDefault();
+		if (!showExtras) {
+			showExtras = true;
+			event.preventDefault();
+		}
 	};
 
 	function handleBurger() {
@@ -167,7 +170,7 @@
 					{...extension}
 					bind:enabled={extension.enabled}
 					bind:showExtras
-					on:contextmenu={onContextMenu}
+					on:contextmenu|once={onContextMenu}
 					{undoStack}
 				/>
 			{/if}


### PR DESCRIPTION
Once the buttons are shown, there's little reason to hide them again. This PR restores the native context menu behavior in that case.

The YouTube video player has the same behavior:

1. first click: custom dropdown
2. second click: native dropdown