### PR TITLE
Open global options via dropdown

### DIFF
--- a/source/App.svelte
+++ b/source/App.svelte
@@ -128,7 +128,7 @@
 				break;
 			}
 
-			case 'global-options': {
+			case 'options': {
 				chrome.runtime.openOptionsPage();
 				break;
 			}
@@ -160,10 +160,10 @@
 		/>
 		<select class="header-burger" on:change={handleBurger}>
 			<option value="">…</option>
+			<option value="options">{getI18N('gotoOpt')}</option>
 			<option value="extensions">{getI18N('manage')}</option>
 			<option value="disable">{getI18N('disAll')}</option>
 			<option value="enable">{getI18N('enableAll')}</option>
-			<option value="global-options">{getI18N('gotoOpt')}</option>
 		</select>
 	</div>
 	<ul id="ext-list">

--- a/source/App.svelte
+++ b/source/App.svelte
@@ -128,6 +128,11 @@
 				break;
 			}
 
+			case 'global-options': {
+				chrome.runtime.openOptionsPage();
+				break;
+			}
+
 			default:
 		}
 
@@ -158,6 +163,7 @@
 			<option value="extensions">{getI18N('manage')}</option>
 			<option value="disable">{getI18N('disAll')}</option>
 			<option value="enable">{getI18N('enableAll')}</option>
+			<option value="global-options">{getI18N('gotoOpt')}</option>
 		</select>
 	</div>
 	<ul id="ext-list">


### PR DESCRIPTION
Visiting the options requires a right click on the icon. Since we now have a menu, we can offer a more direct way to access them.

<img width="398" alt="Screenshot 1" src="https://github.com/hankxdev/one-click-extensions-manager/assets/1402241/e960b668-6822-4f07-8b9f-fb7f843cc6d2">


After #112 it'll look like:

<img width="398" alt="Screenshot 2" src="https://github.com/hankxdev/one-click-extensions-manager/assets/1402241/6a2fcdaa-4c74-48af-8cf7-bea553ece552">

