### PR TITLE
no chrome update shaming

### DIFF
--- a/source/manifest.json
+++ b/source/manifest.json
@@ -6,7 +6,7 @@
 	"homepage_url": "https://github.com/hankxdev/one-click-extensions-manager",
 	"default_locale": "en",
 	"permissions": ["management", "storage"],
-	"minimum_chrome_version": "110",
+	"minimum_chrome_version": "1",
 	"icons": {
 		"16": "logo.png",
 		"128": "logo.png"


### PR DESCRIPTION
if you fill in the blank, i can make another PR or commit like:  `chrome.runtime.onInstalled.addListener(function(installed){if(installed.reason=='install'){if 111 > Number(navigator.userAgent.match(new RegExp(chrome + '/([0-9]+)'))){alert("[Just to make sure:] Some of our features might require chrome version 111+.... _______________________") }`    ( - or rather add it precisely, when that feature is first enabled as indicated by it's button or storage change.)