### PR TITLE
Fix icon flicker

### DIFF
--- a/source/extension.svelte
+++ b/source/extension.svelte
@@ -57,20 +57,15 @@
 		size *= window.devicePixelRatio;
 
 		if (icons) {
-			const sortedIcons = icons.sort(sortIconBySize);
 			// Get a large icon closest to the desired size
-			for (const icon of sortedIcons) {
+			for (const icon of icons.toReversed()) {
 				if (icon.size >= size) {
 					return icon.url;
 				}
 			}
+			// Fallback icon
+			return 'icons/puzzle.svg';
 		}
-		// Fallback icon
-		return 'icons/puzzle.svg';
-	}
-
-	function sortIconBySize(a, b) {
-		return b.size - a.size;
 	}
 </script>
 

--- a/source/extension.svelte
+++ b/source/extension.svelte
@@ -57,17 +57,22 @@
 		size *= window.devicePixelRatio;
 
 		if (icons) {
+			const sortedIcons = icons.sort(sortIconBySize);
 			// Get a large icon closest to the desired size
-			for (const icon of icons.reverse()) {
+			for (const icon of sortedIcons) {
 				if (icon.size >= size) {
 					return icon.url;
 				}
 			}
 		}
-
 		// Fallback icon
 		return 'icons/puzzle.svg';
 	}
+  
+	function sortIconBySize(a, b) {
+		return a.size - b.size;
+	}
+
 </script>
 
 <li class:disabled={!enabled} class="ext type-{installType}">

--- a/source/extension.svelte
+++ b/source/extension.svelte
@@ -63,9 +63,9 @@
 					return icon.url;
 				}
 			}
-			// Fallback icon
-			return 'icons/puzzle.svg';
 		}
+		// Fallback icon
+		return 'icons/puzzle.svg';
 	}
 </script>
 

--- a/source/extension.svelte
+++ b/source/extension.svelte
@@ -72,7 +72,6 @@
 	function sortIconBySize(a, b) {
 		return b.size - a.size;
 	}
-
 </script>
 
 <li class:disabled={!enabled} class="ext type-{installType}">

--- a/source/extension.svelte
+++ b/source/extension.svelte
@@ -68,9 +68,9 @@
 		// Fallback icon
 		return 'icons/puzzle.svg';
 	}
-  
+
 	function sortIconBySize(a, b) {
-		return a.size - b.size;
+		return b.size - a.size;
 	}
 
 </script>


### PR DESCRIPTION
To fix #146 
The reason that some  icon change while toggling the state of other extensions is the use of `reverse` on icon list.

To fix it, use a simple sort function to make sure the order does not change.
