### PR TITLE
Silence console warnings

### DIFF
--- a/source/extension.svelte
+++ b/source/extension.svelte
@@ -10,9 +10,9 @@
 	export let enabled;
 	export let installType;
 	export let homepageUrl;
-	export let updateUrl;
+	export let updateUrl; // Optional
 	export let optionsUrl;
-	export let icons;
+	export let icons; // Optional
 	export let showExtras;
 	export let undoStack;
 
@@ -28,7 +28,7 @@
 			return homepageUrl;
 		}
 
-		return updateUrl.startsWith('https://edge.microsoft.com')
+		return updateUrl?.startsWith('https://edge.microsoft.com')
 			? edgeWebStoreUrl
 			: chromeWebStoreUrl;
 	}

--- a/source/extension.svelte
+++ b/source/extension.svelte
@@ -1,4 +1,7 @@
 <script>
+	// Silence warnings https://github.com/sveltejs/svelte/issues/4652#issuecomment-1666893821
+	$$restProps;
+
 	import openInTab from './lib/open-in-tab.js';
 
 	export let id;

--- a/source/extension.svelte
+++ b/source/extension.svelte
@@ -1,5 +1,6 @@
 <script>
 	// Silence warnings https://github.com/sveltejs/svelte/issues/4652#issuecomment-1666893821
+	// eslint-disable-next-line no-unused-expressions
 	$$restProps;
 
 	import openInTab from './lib/open-in-tab.js';

--- a/source/main.js
+++ b/source/main.js
@@ -11,7 +11,9 @@ if (autoFit) {
 	fitWindow();
 }
 
-chrome.runtime.sendMessage('thisTownIsTooSmallForTheTwoOfUs');
+chrome.runtime.sendMessage('thisTownIsTooSmallForTheTwoOfUs').catch(() => {
+	// No other windows open, good!
+});
 chrome.runtime.onMessage.addListener(message => {
 	if (message === 'thisTownIsTooSmallForTheTwoOfUs') {
 		window.close();


### PR DESCRIPTION
- Fixes #158 

<img width="643" alt="Screenshot 7" src="https://github.com/user-attachments/assets/e5c55f56-a04a-4564-912e-2aeeb6d77555">

The livereload is only in the dev build. It would be nice to fix that eventually but not here