### PR TITLE
Update options style

### DIFF
--- a/source/manifest.json
+++ b/source/manifest.json
@@ -18,9 +18,7 @@
 	"side_panel": {
 		"default_path": "index.html"
 	},
-	"options_ui": {
-		"page": "options/options.html"
-	},
+	"options_page": "options/options.html",
 	"background": {
 		"service_worker": "background.js",
 		"type": "module"

--- a/source/options/options.html
+++ b/source/options/options.html
@@ -1,76 +1,88 @@
 <!doctype html>
-<meta charset="UTF-8" />
-<base target="_blank" />
-<title>One Click Extension Manager options</title>
-<style>
-	@import './webext-base.css';
-	label {
-		display: block;
-	}
-	select {
-		line-height: 2;
-		height: 2.4em; /* Match the height of the input */
-	}
-	ul {
-		padding-left: 1em;
-	}
-	p:has([value='tab']:checked, [value='sidebar']:checked)
-		~ p:has(label[for='width']) {
-		display: none;
-	}
-
-	/* TODO: Drop after https://github.com/fregante/webext-base-css/issues/18 */
-	hr {
-		--body-margin-h: 8px;
-		margin-right: calc(-1 * var(--body-margin-h));
-		margin-left: calc(-1 * var(--body-margin-h));
-		border: none;
-		border-bottom: 1px solid #aaa4;
-	}
-</style>
-<form id="options-form">
+<html class="webext-base-css-modal">
+	<meta charset="UTF-8" />
+	<base target="_blank" />
+	<title>One Click Extension Manager options</title>
+	<style>
+		@import './webext-base.css';
+		body {
+			padding: 20px !important;
+		}
+		hr {
+			--body-margin-h: 20px;
+		}
+		h1 {
+			font-weight: 100;
+			line-height: 1;
+		}
+		label {
+			display: block;
+		}
+		select {
+			line-height: 2;
+			height: 2.4em; /* Match the height of the input */
+		}
+		ul {
+			padding-left: 1em;
+		}
+		p:has([value='tab']:checked, [value='sidebar']:checked)
+			~ p:has(label[for='width']) {
+			display: none;
+		}
+		/* TODO: Drop after https://github.com/fregante/webext-base-css/issues/18 */
+		hr {
+			--body-margin-h: 8px;
+			margin-right: calc(-1 * var(--body-margin-h));
+			margin-left: calc(-1 * var(--body-margin-h));
+			border: none;
+			border-bottom: 1px solid #aaa4;
+		}
+	</style>
+	<script type="module" defer src="options.js"></script>
+	<h1>One-Click Extensions Manager</h1>
+	<form id="options-form">
+		<p>
+			<label for="showButtons">Show buttons</label>
+			<select name="showButtons" id="showButtons">
+				<option value="on-demand">On right click (default)</option>
+				<option value="always">Always</option>
+			</select>
+		</p>
+		<p>
+			<label for="position">Position</label>
+			<select name="position" id="position">
+				<option value="popup">Menu (default)</option>
+				<option value="window">Popup window</option>
+				<option value="tab">Tab</option>
+				<option value="sidebar">Sidebar</option>
+			</select>
+		</p>
+		<p>
+			<label for="width"> Width <small>(in pixels)</small> </label>
+			<input type="text" name="width" id="width" placeholder="400" size="5" />
+		</p>
+	</form>
+	<hr />
 	<p>
-		<label for="showButtons">Show buttons</label>
-		<select name="showButtons" id="showButtons">
-			<option value="on-demand">On right click (default)</option>
-			<option value="always">Always</option>
-		</select>
+		If you find this useful, consider supporting its development by donating or
+		leaving a review.
 	</p>
+	<ul>
+		<li>
+			<a
+				href="https://chrome.google.com/webstore/detail/one-click-extensions-mana/pbgjpgbpljobkekbhnnmlikbbfhbhmem/reviews"
+				>Reviews</a
+			>
+		</li>
+		<li><a href="https://github.com/sponsors/fregante">Donations</a></li>
+		<li>
+			<a href="https://github.com/hankxdev/one-click-extensions-manager"
+				>Open source on GitHub</a
+			>
+		</li>
+	</ul>
 	<p>
-		<label for="position">Position</label>
-		<select name="position" id="position">
-			<option value="popup">Menu (default)</option>
-			<option value="window">Popup window</option>
-			<option value="tab">Tab</option>
-			<option value="sidebar">Sidebar</option>
-		</select>
+		Made by <a href="https://fregante.com">fregante</a> 🇮🇹 and
+		<a href="https://momane.com/">Hank Yang</a> 🇨🇳
 	</p>
-	<p>
-		<label for="width"> Width <small>(in pixels)</small> </label>
-		<input type="text" name="width" id="width" placeholder="400" size="5" />
-	</p>
-</form>
-<hr />
-<p>
-	If you find this useful, consider supporting its development by donating or
-	leaving a review.
-</p>
-<ul>
-	<li>
-		<a
-			href="https://chrome.google.com/webstore/detail/one-click-extensions-mana/pbgjpgbpljobkekbhnnmlikbbfhbhmem/reviews"
-			>Reviews</a
-		>
-	</li>
-	<li><a href="https://github.com/sponsors/fregante">Donations</a></li>
-	<li>
-		<a href="https://github.com/hankxdev/one-click-extensions-manager"
-			>Open source on GitHub</a
-		>
-	</li>
-</ul>
-<p>
-	Made by <a href="https://fregante.com">fregante</a> 🇮🇹 and
-	<a href="https://momane.com/">Hank Yang</a> 🇨🇳
-</p>
-<script type="module" src="options.js"></script>
+</html>

--- a/source/options/webext-base.css
+++ b/source/options/webext-base.css
@@ -6,6 +6,7 @@
 	color-scheme: light dark;
 	max-width: 700px;
 	margin: auto;
+	background: var(--background-color);
 }
 
 body {
@@ -79,10 +80,11 @@ kbd {
 }
 
 /* Firefox-only style */
+/* stylelint-disable-next-line at-rule-no-vendor-prefix */
 @-moz-document url-prefix('') {
 	@media (prefers-color-scheme: dark) {
 		:root {
-			background-color: #23222b;
+			--background-color: #23222b;
 		}
 	}
 }
@@ -92,7 +94,7 @@ kbd {
 	@media (prefers-color-scheme: dark) {
 		:root {
 			/* Safari iOS has a black background */
-			background-color: #1e1e1e;
+			--background-color: #1e1e1e;
 		}
 	}
 }
@@ -103,4 +105,37 @@ kbd {
 	font-family:
 		ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono',
 		monospace !important;
+}
+
+:root.webext-base-css-modal {
+	background: light-dark(#6e9d9f, #194041);
+	min-height: 100vh;
+	display: grid;
+	place-items: center;
+
+	body {
+		max-width: 500px;
+		border-radius: 8px;
+		padding: 8px;
+		background: var(--background-color, light-dark(#fff, #1e1e1e));
+		box-shadow:
+			0.3px 2.8px 2.2px rgb(0 0 0 / 2%),
+			0.8px 6.7px 5.3px rgb(0 0 0 / 2.8%),
+			1.5px 12.5px 10px rgb(0 0 0 / 3.5%),
+			2.7px 22.3px 17.9px rgb(0 0 0 / 4.2%),
+			5px 41.8px 33.4px rgb(0 0 0 / 5%),
+			12px 100px 80px rgb(0 0 0 / 7%);
+	}
+
+	body > :first-child {
+		margin-top: 0;
+	}
+
+	body > :last-child {
+		margin-bottom: 0;
+	}
+
+	hr {
+		margin-inline: -8px;
+	}
 }


### PR DESCRIPTION
- Applies https://github.com/fregante/webext-base-css/issues/18
- Following the webext-base-css update in https://github.com/hankxdev/one-click-extensions-manager/pull/172

The style was actually initially inspired by the style I faked in one of the screenshots here: https://github.com/hankxdev/one-click-extensions-manager/issues/138


## Light

<img width="887" alt="Screenshot 3" src="https://github.com/user-attachments/assets/bec0adb5-a4fd-403c-a269-80ea36c650a8" />


## Dark

<img width="887" alt="Screenshot 2" src="https://github.com/user-attachments/assets/28ef2f06-4e9b-4960-80ed-f63b22e49a81" />
