### PR TITLE
add edge upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,3 +57,20 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
+  Edge:
+    if: needs.Version.outputs.created
+    needs: Version
+    name: Submit (Edge)
+    environment: Edge
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+      - name: Create zip for Edge store
+        working-directory: artifact
+        run: zip -r extension.zip ./*
+      - run: npx edge-webstore-upload@latest upload extension.zip
+        working-directory: artifact
+        env:
+          CLIENT_ID: ${{ secrets.EDGE_CLIENT_ID }}
+          API_KEY: ${{ secrets.EDGE_API_KEY }}
+          PRODUCT_ID: ${{ secrets.EDGE_PRODUCT_ID }}


### PR DESCRIPTION
Use a minimal edge webstore api v1.1 wrapper `edge-webstore-upload` to upload the package there.
