### PR TITLE
Use 2025.x.x version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
         run: npm test
       - name: Create tag if necessary
         uses: fregante/daily-version-action@v2
+        with:
+          prefix: 20 # Use YYYY.M.D instead of YY.M.D
       - name: Update manifest.json with version ${{ env.DAILY_VERSION}}
         if: env.DAILY_VERSION_CREATED
         run: npx dot-json@1 "$DIRECTORY/manifest.json" version "$DAILY_VERSION"


### PR DESCRIPTION
The extension was uploaded to the edge store with the wrong version before (2025.x.x instead of 25.x.x) so instead of complicating the upload process it's best to just standardize around 2025.x.x

- follows https://github.com/hankxdev/one-click-extensions-manager/pull/192