### PR TITLE
Add option to show full name

### DIFF
--- a/source/app.svelte
+++ b/source/app.svelte
@@ -5,6 +5,7 @@
 	import {focusNext, focusPrevious} from './lib/focus-next.js';
 	import prepareExtensionList from './lib/prepare-extension-list.js';
 	import UndoStack from './lib/undo-stack.js';
+	import trimName from './lib/trim-name.js';
 	import optionsStorage, {togglePin} from './options-storage.js';
 
 	const getI18N = chrome.i18n.getMessage;
@@ -17,13 +18,14 @@
 		!localStorage.getItem('sticky-info-message'),
 	);
 	let showInfoMessage = $state(!localStorage.getItem('undo-info-message'));
+	let shortName = $state(true);
 
 	// "Disable/enable all" shows the button again, unless the user clicked already "hide" in the current session
 	let userClickedHideInfoMessage = $state(false);
 
 	const options = optionsStorage.getAll();
 
-	options.then(({showButtons, width, position}) => {
+	options.then(({showButtons, width, position, name}) => {
 		if (showButtons === 'always') {
 			showExtras = true;
 		}
@@ -31,6 +33,8 @@
 		if (position === 'popup' || position === 'window') {
 			document.documentElement.style.width = `${width || 400}px`;
 		}
+
+		shortName = name === 'short';
 	});
 
 	$effect(() => {
@@ -227,6 +231,10 @@
 			{#if extension.shown}
 				<Extension
 					{...extension}
+					name={// The browser will still fill the "short name" with "name" if missing
+					shortName
+						? trimName(extension.shortName ?? extension.name)
+						: extension.name}
 					bind:enabled={extension.enabled}
 					bind:showExtras
 					oncontextmenu={onContextMenu}

--- a/source/app.svelte
+++ b/source/app.svelte
@@ -4,6 +4,7 @@
 	import {replaceModifierIfMac} from './lib/cmd-key.js';
 	import {focusNext, focusPrevious} from './lib/focus-next.js';
 	import prepareExtensionList from './lib/prepare-extension-list.js';
+	import trimName from './lib/trim-name.js';
 	import UndoStack from './lib/undo-stack.js';
 	import optionsStorage, {togglePin} from './options-storage.js';
 
@@ -18,8 +19,9 @@
 	let showStickyInfoMessage = !localStorage.getItem('sticky-info-message');
 	let showInfoMessage = !localStorage.getItem('undo-info-message');
 	let userClickedHideInfoMessage = false; // "Disable/enable all" shows the button again, unless the user clicked already "hide" in the current session
+	let shortName = true;
 
-	options.then(({showButtons, width, position}) => {
+	options.then(({showButtons, width, position, name}) => {
 		if (showButtons === 'always') {
 			showExtras = true;
 		}
@@ -27,6 +29,8 @@
 		if (position === 'popup' || position === 'window') {
 			document.documentElement.style.width = `${width || 400}px`;
 		}
+
+		shortName = name === 'short';
 	});
 	$: {
 		const keywords = searchValue
@@ -221,6 +225,10 @@
 			{#if extension.shown}
 				<Extension
 					{...extension}
+					name={// The browser will still fill the "short name" with "name" if missing
+					shortName
+						? trimName(extension.shortName ?? extension.name)
+						: extension.name}
 					bind:enabled={extension.enabled}
 					bind:showExtras
 					on:contextmenu|once={onContextMenu}

--- a/source/extension.svelte
+++ b/source/extension.svelte
@@ -1,12 +1,10 @@
 <script>
 	import pickBestIcon from './lib/icons.js';
 	import openInTab from './lib/open-in-tab.js';
-	import trimName from './lib/trim-name.js';
 
 	const {
 		id,
 		name,
-		shortName,
 		enabled = $bindable(),
 		installType,
 		homepageUrl,
@@ -28,8 +26,6 @@
 		`https://microsoftedge.microsoft.com/addons/detail/${id}`,
 	);
 	const url = $derived(generateHomeURL());
-	// The browser will still fill the "short name" with "name" if missing
-	const realName = $derived(trimName(shortName ?? name));
 
 	function generateHomeURL() {
 		if (installType !== 'normal') {
@@ -79,7 +75,7 @@
 		onclick={toggleExtension}
 		oncontextmenu={handleContextMenu}
 	>
-		<img alt="" src={pickBestIcon(icons, 16)} />{realName}
+		<img alt="" src={pickBestIcon(icons, 16)} />{name}
 	</button>
 	{#if optionsUrl && enabled}
 		<a href={optionsUrl} title={getI18N('gotoOpt')} onclick={openInTab}>

--- a/source/extension.svelte
+++ b/source/extension.svelte
@@ -6,11 +6,9 @@
 	import {createEventDispatcher} from 'svelte';
 	import pickBestIcon from './lib/icons.js';
 	import openInTab from './lib/open-in-tab.js';
-	import trimName from './lib/trim-name.js';
 
 	export let id;
 	export let name;
-	export let shortName;
 	export let enabled;
 	export let installType;
 	export let homepageUrl;
@@ -25,8 +23,6 @@
 	const chromeWebStoreUrl = `https://chrome.google.com/webstore/detail/${id}`;
 	const edgeWebStoreUrl = `https://microsoftedge.microsoft.com/addons/detail/${id}`;
 	const url = generateHomeURL();
-	// The browser will still fill the "short name" with "name" if missing
-	const realName = trimName(shortName ?? name);
 
 	function generateHomeURL() {
 		if (installType !== 'normal') {
@@ -70,7 +66,7 @@
 		on:click={toggleExtension}
 		on:contextmenu
 	>
-		<img alt="" src={pickBestIcon(icons, 16)} />{realName}
+		<img alt="" src={pickBestIcon(icons, 16)} />{name}
 	</button>
 	{#if optionsUrl && enabled}
 		<a href={optionsUrl} title={getI18N('gotoOpt')} on:click={openInTab}>

--- a/source/options-storage.js
+++ b/source/options-storage.js
@@ -6,6 +6,7 @@ const optionsStorage = new OptionsSync({
 		showButtons: 'on-demand', // Or 'always'
 		width: '',
 		pinnedExtensions: [], // Array of pinned extension IDs
+		name: 'short',
 	},
 	migrations: [
 		options => {

--- a/source/options/options.html
+++ b/source/options/options.html
@@ -58,6 +58,13 @@
 			</select>
 		</p>
 		<p>
+			<label for="name">Display</label>
+			<select name="name" id="name">
+				<option value="short">Short name (default)</option>
+				<option value="full">Full name</option>
+			</select>
+		</p>
+		<p>
 			<label for="width"> Width <small>(in pixels)</small> </label>
 			<input type="text" name="width" id="width" placeholder="400" size="5" />
 		</p>

--- a/source/options/options.html
+++ b/source/options/options.html
@@ -82,16 +82,14 @@
 
 		<fieldset>
 			<legend>Display</legend>
-			<p>
-				<label>
-					<input type="radio" checked name="name" value="short" />
-					Short name (default)
-				</label>
-				<label>
-					<input type="radio" name="name" value="full" />
-					Full name
-				</label>
-			</p>
+			<label>
+				<input type="radio" checked name="name" value="short" />
+				Short name (default)
+			</label>
+			<label>
+				<input type="radio" name="name" value="full" />
+				Full name
+			</label>
 		</fieldset>
 
 		<p>

--- a/source/options/options.html
+++ b/source/options/options.html
@@ -80,6 +80,20 @@
 			</label>
 		</fieldset>
 
+		<fieldset>
+			<legend>Display</legend>
+			<p>
+				<label>
+					<input type="radio" checked name="name" value="short" />
+					Short name (default)
+				</label>
+				<label>
+					<input type="radio" name="name" value="full" />
+					Full name
+				</label>
+			</p>
+		</fieldset>
+
 		<p>
 			<label for="width">Width <small>(in pixels)</small> </label>
 			<input id="width" type="text" name="width" placeholder="400" size="5" />


### PR DESCRIPTION
First mentioned in https://github.com/hankxdev/one-click-extensions-manager/issues/156, then https://chromewebstore.google.com/detail/pbgjpgbpljobkekbhnnmlikbbfhbhmem/reviews/609c038f-34ac-452c-b3ca-4abc80fa3250

I don't really want to go down the path of just following whatever reviews ask for. This specific change is easy enough to do it though.


<img width="551" height="479" alt="Screenshot 11" src="https://github.com/user-attachments/assets/5d426f0a-e123-4fe7-bcfb-9d5051724e11" />
