### PR TITLE
AI SPAM

### DIFF
--- a/.github/ISSUE_TEMPLATE/features.md
+++ b/.github/ISSUE_TEMPLATE/features.md
@@ -1,6 +1,6 @@
 ---
 name: Request new feature
-about: Suggest an idea for One Click Extension Manager
+about: Suggest an idea for OnFire Extensions Manager
 ---
 
 <!--

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,4 +42,5 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: package.json
+      - run: npm ci
       - run: npm run unit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 env:
   DIRECTORY: distribution
-  PROJECT_NAME: one-click-extensions-manager
+  PROJECT_NAME: onfire-extensions-manager
 
 # FILE GENERATED WITH: npx ghat fregante/ghatemplates/webext
 # SOURCE: https://github.com/fregante/ghatemplates

--- a/native-helper/README.md
+++ b/native-helper/README.md
@@ -31,7 +31,7 @@ The installer writes:
 The native messaging manifest restricts access to the installed manager extension ID. The local fallback server also rejects requests whose `Origin` is not that extension.
 
 If macOS reports that `osascript` is not allowed assistive access, grant Accessibility permission to the app running the helper or reinstall the helper from a terminal/Codex session that already has Accessibility permission.
-If macOS reports that `native-host` or `native-clicker` needs Accessibility access, run:
+Normal popup requests check Accessibility access silently so Brave does not show a permission prompt on every click. If macOS reports that `native-host` or `native-clicker` needs Accessibility access, run the explicit prompt command once:
 
 ```sh
 ~/.local/share/one-click-extensions-manager/native-helper/native-host --prompt

--- a/native-helper/README.md
+++ b/native-helper/README.md
@@ -1,6 +1,6 @@
 # Native Popup Helper
 
-Chrome and Brave do not expose an extension API that lets one extension directly open another extension's action popup. This helper provides the practical macOS path: the manager asks a native host to click the target extension in the browser toolbar or Extensions menu.
+Chrome and Brave do not expose an extension API that lets one extension directly open another extension's action popup. This helper provides the practical macOS path: the manager asks a native host to click the target extension in the browser toolbar or Extensions menu. If Brave's accessibility tree does not expose that target, the helper reads the extension's stored manifest and opens its declared popup or options page in a compact Brave window instead of opening a new tab.
 
 Install for Brave:
 
@@ -24,6 +24,7 @@ The installer writes:
 
 - Native messaging manifest: `~/Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts/com.ocem.popuphost.json`
 - Helper files: `~/.local/share/one-click-extensions-manager/native-helper`
+- Browser profile path used for manifest-popup fallback: `~/Library/Application Support/BraveSoftware/Brave-Browser/Default`
 - Local fallback server: `http://127.0.0.1:17645/open-extension-popup`
 - Local helper PID: `~/.local/share/one-click-extensions-manager/native-helper/http-host.pid`
 

--- a/native-helper/README.md
+++ b/native-helper/README.md
@@ -1,8 +1,38 @@
-# Native Popup Helper
+# OnFire Extensions Manager Native Popup Helper
 
-Chrome and Brave do not expose an extension API that lets one extension directly open another extension's action popup. This helper provides the practical macOS path: the manager asks a native host to click the target extension in the browser toolbar or Extensions menu. It uses a small native macOS clicker for consistent Accessibility automation and deliberately does not open `chrome-extension://...` popup or options pages as tabs/windows; if the browser toolbar/menu cannot be automated, the helper returns a clear error instead.
+Chrome and Brave do not expose an extension API that lets one extension directly
+open another extension's action popup. This helper provides the practical
+cross-platform path for OnFire Extensions Manager: the manager asks a local
+helper to click the target extension in the browser toolbar or Extensions menu.
+It deliberately does not open `chrome-extension://...` popup or options pages as
+tabs/windows; if the browser toolbar/menu cannot be automated, the helper
+returns a clear error instead.
 
-Install for Brave:
+## One-command setup
+
+After loading the unpacked extension, copy this extension's ID from
+`chrome://extensions`, then run:
+
+```sh
+npm run helper:install -- <extension-id> brave
+```
+
+Use `chrome` instead of `brave` for Google Chrome. Windows also supports `edge`
+and `chromium`.
+
+Diagnose:
+
+```sh
+npm run helper:diagnose -- brave
+```
+
+Uninstall:
+
+```sh
+npm run helper:uninstall
+```
+
+## Direct macOS commands
 
 ```sh
 bash native-helper/install-macos.sh inbopcbofedcnafadmplaamkbffefmjo brave
@@ -20,7 +50,7 @@ Uninstall:
 bash native-helper/uninstall-macos.sh
 ```
 
-The installer writes:
+The macOS installer writes:
 
 - Native messaging manifest: `~/Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts/com.ocem.popuphost.json`
 - Helper files: `~/.local/share/one-click-extensions-manager/native-helper`
@@ -28,7 +58,32 @@ The installer writes:
 - Local fallback server: `http://127.0.0.1:17645/open-extension-popup`
 - Local helper PID: `~/.local/share/one-click-extensions-manager/native-helper/http-host.pid`
 
-The native messaging manifest restricts access to the installed manager extension ID. The local fallback server also rejects requests whose `Origin` is not that extension.
+The helper directory intentionally keeps the legacy `one-click-extensions-manager`
+path so existing native-host installs continue to work after upgrading this
+fork.
+
+## Direct Windows commands
+
+From PowerShell:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File native-helper/install-windows.ps1 -ExtensionId inbopcbofedcnafadmplaamkbffefmjo -Browser brave
+powershell -ExecutionPolicy Bypass -File native-helper/diagnose-windows.ps1 -Browser brave
+powershell -ExecutionPolicy Bypass -File native-helper/uninstall-windows.ps1
+```
+
+The Windows installer writes:
+
+- Helper files: `%LOCALAPPDATA%\OnFire Extensions Manager\native-helper`
+- Helper config: `%LOCALAPPDATA%\OnFire Extensions Manager\native-helper\native-host-config.json`
+- Per-user scheduled task: `OnFire Extensions Manager Popup Helper`
+- Local helper: `http://127.0.0.1:17645/open-extension-popup`
+
+The scheduled task runs at user logon and does not require administrator rights.
+
+The macOS native messaging manifest restricts access to the installed manager
+extension ID. The local helper server on both platforms also rejects requests
+whose `Origin` is not that extension.
 
 If macOS reports that `osascript` is not allowed assistive access, grant Accessibility permission to the app running the helper or reinstall the helper from a terminal/Codex session that already has Accessibility permission.
 Normal popup requests check Accessibility access silently so Brave does not show a permission prompt on every click. If macOS reports that `native-host` or `native-clicker` needs Accessibility access, run the explicit prompt command once:

--- a/native-helper/README.md
+++ b/native-helper/README.md
@@ -1,6 +1,6 @@
 # Native Popup Helper
 
-Chrome and Brave do not expose an extension API that lets one extension directly open another extension's action popup. This helper provides the practical macOS path: the manager asks a native host to click the target extension in the browser toolbar or Extensions menu. It deliberately does not open `chrome-extension://...` popup or options pages as tabs/windows; if the browser toolbar/menu cannot be automated, the helper returns a clear error instead.
+Chrome and Brave do not expose an extension API that lets one extension directly open another extension's action popup. This helper provides the practical macOS path: the manager asks a native host to click the target extension in the browser toolbar or Extensions menu. It uses a small native macOS clicker for consistent Accessibility automation and deliberately does not open `chrome-extension://...` popup or options pages as tabs/windows; if the browser toolbar/menu cannot be automated, the helper returns a clear error instead.
 
 Install for Brave:
 
@@ -31,3 +31,11 @@ The installer writes:
 The native messaging manifest restricts access to the installed manager extension ID. The local fallback server also rejects requests whose `Origin` is not that extension.
 
 If macOS reports that `osascript` is not allowed assistive access, grant Accessibility permission to the app running the helper or reinstall the helper from a terminal/Codex session that already has Accessibility permission.
+If macOS reports that `native-host` or `native-clicker` needs Accessibility access, run:
+
+```sh
+~/.local/share/one-click-extensions-manager/native-helper/native-host --prompt
+~/.local/share/one-click-extensions-manager/native-helper/native-clicker --prompt
+```
+
+Then grant access in System Settings > Privacy & Security > Accessibility and retry the extension popup.

--- a/native-helper/README.md
+++ b/native-helper/README.md
@@ -1,6 +1,6 @@
 # Native Popup Helper
 
-Chrome and Brave do not expose an extension API that lets one extension directly open another extension's action popup. This helper provides the practical macOS path: the manager asks a native host to click the target extension in the browser toolbar or Extensions menu. If Brave's accessibility tree does not expose that target, the helper reads the extension's stored manifest and opens its declared popup or options page in a compact Brave window instead of opening a new tab.
+Chrome and Brave do not expose an extension API that lets one extension directly open another extension's action popup. This helper provides the practical macOS path: the manager asks a native host to click the target extension in the browser toolbar or Extensions menu. It deliberately does not open `chrome-extension://...` popup or options pages as tabs/windows; if the browser toolbar/menu cannot be automated, the helper returns a clear error instead.
 
 Install for Brave:
 
@@ -24,7 +24,7 @@ The installer writes:
 
 - Native messaging manifest: `~/Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts/com.ocem.popuphost.json`
 - Helper files: `~/.local/share/one-click-extensions-manager/native-helper`
-- Browser profile path used for manifest-popup fallback: `~/Library/Application Support/BraveSoftware/Brave-Browser/Default`
+- Browser profile path used by diagnostics: `~/Library/Application Support/BraveSoftware/Brave-Browser/Default`
 - Local fallback server: `http://127.0.0.1:17645/open-extension-popup`
 - Local helper PID: `~/.local/share/one-click-extensions-manager/native-helper/http-host.pid`
 

--- a/native-helper/README.md
+++ b/native-helper/README.md
@@ -1,0 +1,29 @@
+# Native Popup Helper
+
+Chrome and Brave do not expose an extension API that lets one extension directly open another extension's action popup. This helper provides the practical macOS path: the manager asks a native host to click the target extension in the browser toolbar or Extensions menu.
+
+Install for Brave:
+
+```sh
+bash native-helper/install-macos.sh inbopcbofedcnafadmplaamkbffefmjo brave
+```
+
+Diagnose:
+
+```sh
+bash native-helper/diagnose-macos.sh brave
+```
+
+Uninstall:
+
+```sh
+bash native-helper/uninstall-macos.sh
+```
+
+The installer writes:
+
+- Native messaging manifest: `~/Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts/com.ocem.popuphost.json`
+- Helper files: `~/.local/share/one-click-extensions-manager/native-helper`
+- Local fallback server: `http://127.0.0.1:17645/open-extension-popup`
+
+The native messaging manifest restricts access to the installed manager extension ID. The local fallback server also rejects requests whose `Origin` is not that extension.

--- a/native-helper/README.md
+++ b/native-helper/README.md
@@ -25,5 +25,8 @@ The installer writes:
 - Native messaging manifest: `~/Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts/com.ocem.popuphost.json`
 - Helper files: `~/.local/share/one-click-extensions-manager/native-helper`
 - Local fallback server: `http://127.0.0.1:17645/open-extension-popup`
+- Local helper PID: `~/.local/share/one-click-extensions-manager/native-helper/http-host.pid`
 
 The native messaging manifest restricts access to the installed manager extension ID. The local fallback server also rejects requests whose `Origin` is not that extension.
+
+If macOS reports that `osascript` is not allowed assistive access, grant Accessibility permission to the app running the helper or reinstall the helper from a terminal/Codex session that already has Accessibility permission.

--- a/native-helper/diagnose-macos.sh
+++ b/native-helper/diagnose-macos.sh
@@ -23,8 +23,25 @@ pid_file="$helper_dir/http-host.pid"
 
 [[ -f "$manifest" ]] && echo "[OK] Native manifest exists: $manifest" || echo "[FAIL] Missing native manifest: $manifest"
 [[ -x "$helper_dir/native-host" ]] && echo "[OK] Native host executable exists" || echo "[FAIL] Missing native host executable"
+[[ -x "$helper_dir/native-clicker" ]] && echo "[OK] Native clicker executable exists" || echo "[FAIL] Missing native clicker executable"
 [[ -f "$helper_dir/native-host-config.json" ]] && echo "[OK] Native host config exists" || echo "[FAIL] Missing native host config"
 [[ -f "$helper_dir/native-http-host.mjs" ]] && echo "[OK] Local helper script exists" || echo "[FAIL] Missing local helper script"
+
+if [[ -x "$helper_dir/native-clicker" ]]; then
+	if "$helper_dir/native-clicker" --check >/dev/null 2>&1; then
+		echo "[OK] Native clicker has Accessibility access"
+	else
+		echo "[FAIL] Native clicker needs Accessibility access. Run: \"$helper_dir/native-clicker\" --prompt"
+	fi
+fi
+
+if [[ -x "$helper_dir/native-host" ]]; then
+	if "$helper_dir/native-host" --check >/dev/null 2>&1; then
+		echo "[OK] Native host has Accessibility access"
+	else
+		echo "[FAIL] Native host needs Accessibility access. Run: \"$helper_dir/native-host\" --prompt"
+	fi
+fi
 [[ -f "$plist" ]] && echo "[OK] LaunchAgent exists: $plist" || echo "[FAIL] Missing LaunchAgent: $plist"
 
 if [[ -f "$helper_dir/native-host-config.json" ]]; then

--- a/native-helper/diagnose-macos.sh
+++ b/native-helper/diagnose-macos.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+browser="${1:-brave}"
+case "$browser" in
+	brave)
+		manifest="$HOME/Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts/com.ocem.popuphost.json"
+		;;
+	chrome)
+		manifest="$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts/com.ocem.popuphost.json"
+		;;
+	*)
+		echo "[FAIL] Unsupported browser: $browser"
+		exit 2
+		;;
+esac
+
+helper_dir="$HOME/.local/share/one-click-extensions-manager/native-helper"
+
+[[ -f "$manifest" ]] && echo "[OK] Native manifest exists: $manifest" || echo "[FAIL] Missing native manifest: $manifest"
+[[ -x "$helper_dir/native-host" ]] && echo "[OK] Native host executable exists" || echo "[FAIL] Missing native host executable"
+[[ -f "$helper_dir/native-host-config.json" ]] && echo "[OK] Native host config exists" || echo "[FAIL] Missing native host config"
+[[ -f "$helper_dir/native-http-host.mjs" ]] && echo "[OK] Local helper script exists" || echo "[FAIL] Missing local helper script"
+
+node <<'NODE' || true
+try {
+	const response = await fetch('http://127.0.0.1:17645/health');
+	console.log(response.ok ? '[OK] Local helper health is reachable' : `[FAIL] Local helper returned HTTP ${response.status}`);
+} catch (error) {
+	console.log(`[FAIL] Local helper is not reachable: ${error.message}`);
+}
+NODE

--- a/native-helper/diagnose-macos.sh
+++ b/native-helper/diagnose-macos.sh
@@ -27,6 +27,21 @@ pid_file="$helper_dir/http-host.pid"
 [[ -f "$helper_dir/native-http-host.mjs" ]] && echo "[OK] Local helper script exists" || echo "[FAIL] Missing local helper script"
 [[ -f "$plist" ]] && echo "[OK] LaunchAgent exists: $plist" || echo "[FAIL] Missing LaunchAgent: $plist"
 
+if [[ -f "$helper_dir/native-host-config.json" ]]; then
+	HELPER_CONFIG="$helper_dir/native-host-config.json" node <<'NODE' || true
+const fs = require('node:fs');
+const config = JSON.parse(fs.readFileSync(process.env.HELPER_CONFIG, 'utf8'));
+if (config.browserProfilePath) {
+	const securePreferences = `${config.browserProfilePath}/Secure Preferences`;
+	console.log(
+		fs.existsSync(securePreferences)
+			? `[OK] Browser profile preferences found: ${securePreferences}`
+			: `[WARN] Browser profile preferences missing: ${securePreferences}`,
+	);
+}
+NODE
+fi
+
 standalone_running=false
 if [[ -f "$pid_file" ]]; then
 	pid="$(cat "$pid_file" || true)"

--- a/native-helper/diagnose-macos.sh
+++ b/native-helper/diagnose-macos.sh
@@ -16,11 +16,37 @@ case "$browser" in
 esac
 
 helper_dir="$HOME/.local/share/one-click-extensions-manager/native-helper"
+label="com.ocem.popuphost.http"
+plist="$HOME/Library/LaunchAgents/$label.plist"
+service="gui/$(id -u)/$label"
+pid_file="$helper_dir/http-host.pid"
 
 [[ -f "$manifest" ]] && echo "[OK] Native manifest exists: $manifest" || echo "[FAIL] Missing native manifest: $manifest"
 [[ -x "$helper_dir/native-host" ]] && echo "[OK] Native host executable exists" || echo "[FAIL] Missing native host executable"
 [[ -f "$helper_dir/native-host-config.json" ]] && echo "[OK] Native host config exists" || echo "[FAIL] Missing native host config"
 [[ -f "$helper_dir/native-http-host.mjs" ]] && echo "[OK] Local helper script exists" || echo "[FAIL] Missing local helper script"
+[[ -f "$plist" ]] && echo "[OK] LaunchAgent exists: $plist" || echo "[FAIL] Missing LaunchAgent: $plist"
+
+standalone_running=false
+if [[ -f "$pid_file" ]]; then
+	pid="$(cat "$pid_file" || true)"
+	if [[ "$pid" =~ ^[0-9]+$ ]] && kill -0 "$pid" 2>/dev/null; then
+		standalone_running=true
+		echo "[OK] Standalone local helper is running: pid $pid"
+	fi
+fi
+
+if command -v launchctl >/dev/null 2>&1; then
+	if launchctl print "$service" >/dev/null 2>&1; then
+		echo "[OK] LaunchAgent is loaded: $service"
+	elif [[ "$standalone_running" == true ]]; then
+		echo "[OK] LaunchAgent is not loaded; standalone helper mode is active"
+	else
+		echo "[FAIL] LaunchAgent is not loaded: $service"
+	fi
+else
+	echo "[WARN] launchctl is unavailable"
+fi
 
 node <<'NODE' || true
 try {

--- a/native-helper/diagnose-windows.ps1
+++ b/native-helper/diagnose-windows.ps1
@@ -1,0 +1,64 @@
+param(
+	[ValidateSet('brave', 'chrome', 'edge', 'chromium')]
+	[string] $Browser = 'brave'
+)
+
+$installDir = Join-Path $env:LOCALAPPDATA 'OnFire Extensions Manager\native-helper'
+$configPath = Join-Path $installDir 'native-host-config.json'
+$taskName = 'OnFire Extensions Manager Popup Helper'
+
+function Write-Check {
+	param(
+		[bool] $Ok,
+		[string] $Message
+	)
+
+	if ($Ok) {
+		Write-Host "[OK] $Message"
+	} else {
+		Write-Host "[FAIL] $Message"
+	}
+}
+
+$node = Get-Command node -ErrorAction SilentlyContinue
+Write-Check ([bool] $node) 'Node.js is available'
+Write-Check (Test-Path (Join-Path $installDir 'native-host.mjs')) "Native host script exists: $installDir"
+Write-Check (Test-Path (Join-Path $installDir 'native-http-host.mjs')) 'Local helper script exists'
+Write-Check (Test-Path $configPath) 'Native host config exists'
+
+if (Test-Path $configPath) {
+	try {
+		$config = Get-Content -Raw $configPath | ConvertFrom-Json
+		Write-Check ($config.extensionId -match '^[a-p]{32}$') "Configured extension id: $($config.extensionId)"
+		if ($config.browserProcessNames) {
+			Write-Host "[OK] Browser process names: $($config.browserProcessNames -join ', ')"
+		}
+	} catch {
+		Write-Host "[FAIL] Native host config is invalid JSON: $($_.Exception.Message)"
+	}
+}
+
+$task = Get-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
+Write-Check ([bool] $task) "Scheduled task exists: $taskName"
+if ($task) {
+	Write-Host "[OK] Scheduled task state: $($task.State)"
+}
+
+try {
+	$response = Invoke-RestMethod -Uri 'http://127.0.0.1:17645/health' -TimeoutSec 2
+	Write-Check ($response.ok) 'Local helper health endpoint is responding'
+} catch {
+	Write-Host "[FAIL] Local helper health endpoint failed: $($_.Exception.Message)"
+}
+
+$processNames = @{
+	brave = @('brave')
+	chrome = @('chrome')
+	edge = @('msedge')
+	chromium = @('chromium')
+}[$Browser]
+
+$browserProcess = $processNames | ForEach-Object {
+	Get-Process -Name $_ -ErrorAction SilentlyContinue | Where-Object { $_.MainWindowHandle -ne 0 }
+} | Select-Object -First 1
+Write-Check ([bool] $browserProcess) "Running browser window found for $Browser"

--- a/native-helper/diagnose.mjs
+++ b/native-helper/diagnose.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+import {spawnSync} from 'node:child_process';
+import path from 'node:path';
+import process from 'node:process';
+import {fileURLToPath} from 'node:url';
+
+const helperDirectory = path.dirname(fileURLToPath(import.meta.url));
+const [browser = 'brave'] = process.argv.slice(2);
+
+function powershellPath() {
+	if (process.env.SystemRoot) {
+		return path.join(
+			process.env.SystemRoot,
+			'System32',
+			'WindowsPowerShell',
+			'v1.0',
+			'powershell.exe',
+		);
+	}
+
+	return 'powershell.exe';
+}
+
+function run(command, arguments_) {
+	const result = spawnSync(command, arguments_, {stdio: 'inherit'});
+	process.exit(result.status ?? 1);
+}
+
+if (process.platform === 'darwin') {
+	run('bash', [path.join(helperDirectory, 'diagnose-macos.sh'), browser]);
+}
+
+if (process.platform === 'win32') {
+	run(powershellPath(), [
+		'-NoProfile',
+		'-ExecutionPolicy',
+		'Bypass',
+		'-File',
+		path.join(helperDirectory, 'diagnose-windows.ps1'),
+		'-Browser',
+		browser,
+	]);
+}
+
+console.error(
+	'The native popup helper diagnostics support macOS and Windows only.',
+);
+process.exit(1);

--- a/native-helper/install-macos.sh
+++ b/native-helper/install-macos.sh
@@ -12,6 +12,7 @@ fi
 case "$browser" in
 	brave)
 		browser_app="Brave Browser"
+		profile_path="${OCEM_BROWSER_PROFILE:-$HOME/Library/Application Support/BraveSoftware/Brave-Browser/Default}"
 		manifest_dirs=(
 			"$HOME/Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts"
 			"$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts"
@@ -20,6 +21,7 @@ case "$browser" in
 		;;
 	chrome)
 		browser_app="Google Chrome"
+		profile_path="${OCEM_BROWSER_PROFILE:-$HOME/Library/Application Support/Google/Chrome/Default}"
 		manifest_dirs=(
 			"$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts"
 			"$HOME/Library/Application Support/Chromium/NativeMessagingHosts"
@@ -60,7 +62,8 @@ chmod 755 "$install_dir/native-host"
 cat >"$install_dir/native-host-config.json" <<EOF
 {
   "browserApp": "$browser_app",
-  "extensionId": "$extension_id"
+  "extensionId": "$extension_id",
+  "browserProfilePath": "$profile_path"
 }
 EOF
 

--- a/native-helper/install-macos.sh
+++ b/native-helper/install-macos.sh
@@ -69,23 +69,33 @@ cat >"$manifest_dir/com.ocem.popuphost.json" <<EOF
 }
 EOF
 
-plist_path="$HOME/Library/LaunchAgents/com.ocem.popuphost.http.plist"
+rm -f \
+	"$manifest_dir/com.one_click_extensions_manager.popup_helper.json" \
+	"$manifest_dir/com.oneclickextensionsmanager.popuphelper.json" \
+	"$manifest_dir/com.openai.ocemtest.json"
+
+label="com.ocem.popuphost.http"
+plist_path="$HOME/Library/LaunchAgents/$label.plist"
 cat >"$plist_path" <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>Label</key>
-	<string>com.ocem.popuphost.http</string>
+	<string>$label</string>
 	<key>ProgramArguments</key>
 	<array>
 		<string>$node_bin</string>
 		<string>$install_dir/native-http-host.mjs</string>
 	</array>
+	<key>WorkingDirectory</key>
+	<string>$install_dir</string>
 	<key>RunAtLoad</key>
 	<true/>
 	<key>KeepAlive</key>
 	<true/>
+	<key>ProcessType</key>
+	<string>Interactive</string>
 	<key>StandardOutPath</key>
 	<string>/tmp/com.ocem.popuphost.http.log</string>
 	<key>StandardErrorPath</key>
@@ -102,16 +112,45 @@ if [[ -f "$pid_file" ]]; then
 	fi
 fi
 
-nohup "$node_bin" "$install_dir/native-http-host.mjs" >/tmp/com.ocem.popuphost.http.log 2>/tmp/com.ocem.popuphost.http.err &
-echo "$!" >"$pid_file"
-
-sleep 0.8
-"$node_bin" <<'NODE'
-const response = await fetch('http://127.0.0.1:17645/health');
-if (!response.ok) {
-	throw new Error(`Health check failed with HTTP ${response.status}`);
+start_standalone_helper() {
+	nohup "$node_bin" "$install_dir/native-http-host.mjs" >/tmp/com.ocem.popuphost.http.log 2>/tmp/com.ocem.popuphost.http.err &
+	echo "$!" >"$pid_file"
+	echo "Started local helper with nohup fallback."
 }
+
+wait_for_health() {
+	"$node_bin" <<'NODE'
+const deadline = Date.now() + 5000;
+let lastError = '';
+while (Date.now() < deadline) {
+	try {
+		const response = await fetch('http://127.0.0.1:17645/health');
+		if (response.ok) {
+			process.exit(0);
+		}
+
+		lastError = `HTTP ${response.status}`;
+	} catch (error) {
+		lastError = error.message;
+	}
+
+	await new Promise(resolve => {
+		setTimeout(resolve, 250);
+	});
+}
+throw new Error(`Local helper health check failed: ${lastError}`);
 NODE
+}
+
+if command -v launchctl >/dev/null 2>&1; then
+	gui_domain="gui/$(id -u)"
+	launchctl bootout "$gui_domain" "$plist_path" >/dev/null 2>&1 || true
+	launchctl bootout "$gui_domain/$label" >/dev/null 2>&1 || true
+fi
+
+start_standalone_helper
+
+wait_for_health
 
 echo "Installed native popup helper."
 echo "Native host manifest: $manifest_dir/com.ocem.popuphost.json"

--- a/native-helper/install-macos.sh
+++ b/native-helper/install-macos.sh
@@ -48,9 +48,11 @@ cp "$script_dir/native-http-host.mjs" "$install_dir/native-http-host.mjs"
 chmod 755 "$install_dir/native-host.mjs" "$install_dir/native-http-host.mjs"
 
 if command -v cc >/dev/null 2>&1; then
-	cc "$script_dir/native-host-launcher.c" \
-		-DOCEM_NODE_BIN="\"$node_bin\"" \
-		-o "$install_dir/native-host"
+	cc "$script_dir/native-clicker.m" \
+		-framework Cocoa \
+		-framework ApplicationServices \
+		-o "$install_dir/native-clicker"
+	cp "$install_dir/native-clicker" "$install_dir/native-host"
 else
 	cat >"$install_dir/native-host" <<EOF
 #!/usr/bin/env bash
@@ -58,6 +60,9 @@ exec "$node_bin" "$install_dir/native-host.mjs"
 EOF
 fi
 chmod 755 "$install_dir/native-host"
+if [[ -f "$install_dir/native-clicker" ]]; then
+	chmod 755 "$install_dir/native-clicker"
+fi
 
 cat >"$install_dir/native-host-config.json" <<EOF
 {
@@ -162,7 +167,16 @@ if command -v launchctl >/dev/null 2>&1; then
 	launchctl bootout "$gui_domain/$label" >/dev/null 2>&1 || true
 fi
 
-start_standalone_helper
+if command -v launchctl >/dev/null 2>&1; then
+	if launchctl bootstrap "$gui_domain" "$plist_path" >/dev/null 2>&1; then
+		launchctl kickstart -k "$gui_domain/$label" >/dev/null 2>&1 || true
+		echo "Started local helper LaunchAgent: $label"
+	else
+		start_standalone_helper
+	fi
+else
+	start_standalone_helper
+fi
 
 wait_for_health
 

--- a/native-helper/install-macos.sh
+++ b/native-helper/install-macos.sh
@@ -95,7 +95,7 @@ manifest_path="$install_dir/com.ocem.popuphost.json"
 cat >"$manifest_path" <<EOF
 {
   "name": "com.ocem.popuphost",
-  "description": "One Click Extensions Manager popup opener",
+  "description": "OnFire Extensions Manager popup opener",
   "path": "$install_dir/native-host",
   "type": "stdio",
   "allowed_origins": [

--- a/native-helper/install-macos.sh
+++ b/native-helper/install-macos.sh
@@ -12,11 +12,18 @@ fi
 case "$browser" in
 	brave)
 		browser_app="Brave Browser"
-		manifest_dir="$HOME/Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts"
+		manifest_dirs=(
+			"$HOME/Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts"
+			"$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts"
+			"$HOME/Library/Application Support/Chromium/NativeMessagingHosts"
+		)
 		;;
 	chrome)
 		browser_app="Google Chrome"
-		manifest_dir="$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts"
+		manifest_dirs=(
+			"$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts"
+			"$HOME/Library/Application Support/Chromium/NativeMessagingHosts"
+		)
 		;;
 	*)
 		echo "Unsupported browser: $browser" >&2
@@ -33,7 +40,7 @@ if [[ -z "$node_bin" ]]; then
 	exit 1
 fi
 
-mkdir -p "$install_dir" "$manifest_dir" "$HOME/Library/LaunchAgents"
+mkdir -p "$install_dir" "$HOME/Library/LaunchAgents" "${manifest_dirs[@]}"
 cp "$script_dir/native-host.mjs" "$install_dir/native-host.mjs"
 cp "$script_dir/native-http-host.mjs" "$install_dir/native-http-host.mjs"
 chmod 755 "$install_dir/native-host.mjs" "$install_dir/native-http-host.mjs"
@@ -57,7 +64,8 @@ cat >"$install_dir/native-host-config.json" <<EOF
 }
 EOF
 
-cat >"$manifest_dir/com.ocem.popuphost.json" <<EOF
+manifest_path="$install_dir/com.ocem.popuphost.json"
+cat >"$manifest_path" <<EOF
 {
   "name": "com.ocem.popuphost",
   "description": "One Click Extensions Manager popup opener",
@@ -69,10 +77,13 @@ cat >"$manifest_dir/com.ocem.popuphost.json" <<EOF
 }
 EOF
 
-rm -f \
-	"$manifest_dir/com.one_click_extensions_manager.popup_helper.json" \
-	"$manifest_dir/com.oneclickextensionsmanager.popuphelper.json" \
-	"$manifest_dir/com.openai.ocemtest.json"
+for manifest_dir in "${manifest_dirs[@]}"; do
+	cp "$manifest_path" "$manifest_dir/com.ocem.popuphost.json"
+	rm -f \
+		"$manifest_dir/com.one_click_extensions_manager.popup_helper.json" \
+		"$manifest_dir/com.oneclickextensionsmanager.popuphelper.json" \
+		"$manifest_dir/com.openai.ocemtest.json"
+done
 
 label="com.ocem.popuphost.http"
 plist_path="$HOME/Library/LaunchAgents/$label.plist"
@@ -153,6 +164,9 @@ start_standalone_helper
 wait_for_health
 
 echo "Installed native popup helper."
-echo "Native host manifest: $manifest_dir/com.ocem.popuphost.json"
+echo "Native host manifests:"
+for manifest_dir in "${manifest_dirs[@]}"; do
+	echo "- $manifest_dir/com.ocem.popuphost.json"
+done
 echo "Installed helper: $install_dir"
 echo "Local helper: http://127.0.0.1:17645/open-extension-popup"

--- a/native-helper/install-macos.sh
+++ b/native-helper/install-macos.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+extension_id="${1:-}"
+browser="${2:-brave}"
+
+if [[ ! "$extension_id" =~ ^[a-p]{32}$ ]]; then
+	echo "Usage: $0 <32-character-extension-id> [brave|chrome]" >&2
+	exit 2
+fi
+
+case "$browser" in
+	brave)
+		browser_app="Brave Browser"
+		manifest_dir="$HOME/Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts"
+		;;
+	chrome)
+		browser_app="Google Chrome"
+		manifest_dir="$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts"
+		;;
+	*)
+		echo "Unsupported browser: $browser" >&2
+		exit 2
+		;;
+esac
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+install_dir="$HOME/.local/share/one-click-extensions-manager/native-helper"
+node_bin="$(command -v node || true)"
+
+if [[ -z "$node_bin" ]]; then
+	echo "Node.js is required to install the native popup helper." >&2
+	exit 1
+fi
+
+mkdir -p "$install_dir" "$manifest_dir" "$HOME/Library/LaunchAgents"
+cp "$script_dir/native-host.mjs" "$install_dir/native-host.mjs"
+cp "$script_dir/native-http-host.mjs" "$install_dir/native-http-host.mjs"
+chmod 755 "$install_dir/native-host.mjs" "$install_dir/native-http-host.mjs"
+
+if command -v cc >/dev/null 2>&1; then
+	cc "$script_dir/native-host-launcher.c" \
+		-DOCEM_NODE_BIN="\"$node_bin\"" \
+		-o "$install_dir/native-host"
+else
+	cat >"$install_dir/native-host" <<EOF
+#!/usr/bin/env bash
+exec "$node_bin" "$install_dir/native-host.mjs"
+EOF
+fi
+chmod 755 "$install_dir/native-host"
+
+cat >"$install_dir/native-host-config.json" <<EOF
+{
+  "browserApp": "$browser_app",
+  "extensionId": "$extension_id"
+}
+EOF
+
+cat >"$manifest_dir/com.ocem.popuphost.json" <<EOF
+{
+  "name": "com.ocem.popuphost",
+  "description": "One Click Extensions Manager popup opener",
+  "path": "$install_dir/native-host",
+  "type": "stdio",
+  "allowed_origins": [
+    "chrome-extension://$extension_id/"
+  ]
+}
+EOF
+
+plist_path="$HOME/Library/LaunchAgents/com.ocem.popuphost.http.plist"
+cat >"$plist_path" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.ocem.popuphost.http</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>$node_bin</string>
+		<string>$install_dir/native-http-host.mjs</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<true/>
+	<key>StandardOutPath</key>
+	<string>/tmp/com.ocem.popuphost.http.log</string>
+	<key>StandardErrorPath</key>
+	<string>/tmp/com.ocem.popuphost.http.err</string>
+</dict>
+</plist>
+EOF
+
+pid_file="$install_dir/http-host.pid"
+if [[ -f "$pid_file" ]]; then
+	old_pid="$(cat "$pid_file" || true)"
+	if [[ "$old_pid" =~ ^[0-9]+$ ]] && kill -0 "$old_pid" 2>/dev/null; then
+		kill "$old_pid" || true
+	fi
+fi
+
+nohup "$node_bin" "$install_dir/native-http-host.mjs" >/tmp/com.ocem.popuphost.http.log 2>/tmp/com.ocem.popuphost.http.err &
+echo "$!" >"$pid_file"
+
+sleep 0.8
+"$node_bin" <<'NODE'
+const response = await fetch('http://127.0.0.1:17645/health');
+if (!response.ok) {
+	throw new Error(`Health check failed with HTTP ${response.status}`);
+}
+NODE
+
+echo "Installed native popup helper."
+echo "Native host manifest: $manifest_dir/com.ocem.popuphost.json"
+echo "Installed helper: $install_dir"
+echo "Local helper: http://127.0.0.1:17645/open-extension-popup"

--- a/native-helper/install-macos.sh
+++ b/native-helper/install-macos.sh
@@ -47,17 +47,36 @@ cp "$script_dir/native-host.mjs" "$install_dir/native-host.mjs"
 cp "$script_dir/native-http-host.mjs" "$install_dir/native-http-host.mjs"
 chmod 755 "$install_dir/native-host.mjs" "$install_dir/native-http-host.mjs"
 
+install_if_changed() {
+	local source_path="$1"
+	local target_path="$2"
+
+	if [[ -f "$target_path" ]] && cmp -s "$source_path" "$target_path"; then
+		chmod 755 "$target_path"
+		return
+	fi
+
+	cp "$source_path" "$target_path"
+	chmod 755 "$target_path"
+}
+
 if command -v cc >/dev/null 2>&1; then
+	tmp_clicker="$install_dir/native-clicker.tmp.$$"
 	cc "$script_dir/native-clicker.m" \
 		-framework Cocoa \
 		-framework ApplicationServices \
-		-o "$install_dir/native-clicker"
-	cp "$install_dir/native-clicker" "$install_dir/native-host"
+		-o "$tmp_clicker"
+	install_if_changed "$tmp_clicker" "$install_dir/native-clicker"
+	install_if_changed "$tmp_clicker" "$install_dir/native-host"
+	rm -f "$tmp_clicker"
 else
-	cat >"$install_dir/native-host" <<EOF
+	tmp_host="$install_dir/native-host.tmp.$$"
+	cat >"$tmp_host" <<EOF
 #!/usr/bin/env bash
 exec "$node_bin" "$install_dir/native-host.mjs"
 EOF
+	install_if_changed "$tmp_host" "$install_dir/native-host"
+	rm -f "$tmp_host"
 fi
 chmod 755 "$install_dir/native-host"
 if [[ -f "$install_dir/native-clicker" ]]; then

--- a/native-helper/install-windows.ps1
+++ b/native-helper/install-windows.ps1
@@ -1,0 +1,110 @@
+param(
+	[Parameter(Mandatory = $true)]
+	[string] $ExtensionId,
+
+	[ValidateSet('brave', 'chrome', 'edge', 'chromium')]
+	[string] $Browser = 'brave'
+)
+
+$ErrorActionPreference = 'Stop'
+
+if ($ExtensionId -notmatch '^[a-p]{32}$') {
+	Write-Error 'Usage: install-windows.ps1 -ExtensionId <32-character-extension-id> [-Browser brave|chrome|edge|chromium]'
+	exit 2
+}
+
+$browserConfigs = @{
+	brave = @{
+		DisplayName = 'Brave'
+		ProcessNames = @('brave')
+	}
+	chrome = @{
+		DisplayName = 'Google Chrome'
+		ProcessNames = @('chrome')
+	}
+	edge = @{
+		DisplayName = 'Microsoft Edge'
+		ProcessNames = @('msedge')
+	}
+	chromium = @{
+		DisplayName = 'Chromium'
+		ProcessNames = @('chromium')
+	}
+}
+
+$node = Get-Command node -ErrorAction SilentlyContinue
+if (-not $node) {
+	Write-Error 'Node.js is required. Install Node.js, restart PowerShell, then run this installer again.'
+	exit 1
+}
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$installDir = Join-Path $env:LOCALAPPDATA 'OnFire Extensions Manager\native-helper'
+$configPath = Join-Path $installDir 'native-host-config.json'
+$pidPath = Join-Path $installDir 'http-host.pid'
+$taskName = 'OnFire Extensions Manager Popup Helper'
+$browserConfig = $browserConfigs[$Browser]
+
+New-Item -ItemType Directory -Force -Path $installDir | Out-Null
+Copy-Item -Force -Path (Join-Path $scriptDir 'native-host.mjs') -Destination (Join-Path $installDir 'native-host.mjs')
+Copy-Item -Force -Path (Join-Path $scriptDir 'native-http-host.mjs') -Destination (Join-Path $installDir 'native-http-host.mjs')
+
+$config = [ordered]@{
+	extensionId = $ExtensionId
+	browserDisplayName = $browserConfig.DisplayName
+	browserProcessNames = $browserConfig.ProcessNames
+}
+$json = $config | ConvertTo-Json -Depth 4
+$utf8NoBom = New-Object System.Text.UTF8Encoding $false
+[System.IO.File]::WriteAllText($configPath, $json, $utf8NoBom)
+
+function Test-OnFireHelperHealth {
+	param([int] $Attempts = 20)
+
+	for ($index = 0; $index -lt $Attempts; $index++) {
+		try {
+			$response = Invoke-RestMethod -Uri 'http://127.0.0.1:17645/health' -TimeoutSec 2
+			if ($response.ok) {
+				return $true
+			}
+		} catch {}
+
+		Start-Sleep -Milliseconds 250
+	}
+
+	return $false
+}
+
+if (Get-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue) {
+	Stop-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
+	Unregister-ScheduledTask -TaskName $taskName -Confirm:$false
+}
+
+if (Test-Path $pidPath) {
+	$oldPid = Get-Content $pidPath -ErrorAction SilentlyContinue
+	if ($oldPid -match '^[0-9]+$') {
+		Stop-Process -Id ([int] $oldPid) -ErrorAction SilentlyContinue
+	}
+}
+
+$hostScript = Join-Path $installDir 'native-http-host.mjs'
+$action = New-ScheduledTaskAction -Execute $node.Source -Argument "`"$hostScript`"" -WorkingDirectory $installDir
+$trigger = New-ScheduledTaskTrigger -AtLogOn
+$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DisallowStartIfOnBatteries:$false -MultipleInstances IgnoreNew
+$settings.ExecutionTimeLimit = [TimeSpan]::Zero
+Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger -Settings $settings -Description 'Runs the OnFire Extensions Manager local popup helper.' -Force | Out-Null
+Start-ScheduledTask -TaskName $taskName
+
+if (-not (Test-OnFireHelperHealth)) {
+	$process = Start-Process -FilePath $node.Source -ArgumentList "`"$hostScript`"" -WorkingDirectory $installDir -WindowStyle Hidden -PassThru
+	Set-Content -Path $pidPath -Value $process.Id -Encoding ascii
+	if (-not (Test-OnFireHelperHealth)) {
+		Write-Error 'Installed files, but the local helper did not pass its health check.'
+		exit 1
+	}
+}
+
+Write-Host '[OK] Installed OnFire Extensions Manager popup helper for Windows.'
+Write-Host "[OK] Helper files: $installDir"
+Write-Host "[OK] Scheduled task: $taskName"
+Write-Host '[OK] Local helper: http://127.0.0.1:17645/open-extension-popup'

--- a/native-helper/install.mjs
+++ b/native-helper/install.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+import {spawnSync} from 'node:child_process';
+import path from 'node:path';
+import process from 'node:process';
+import {fileURLToPath} from 'node:url';
+
+const helperDirectory = path.dirname(fileURLToPath(import.meta.url));
+const [extensionId, browser = 'brave'] = process.argv.slice(2);
+
+function usage() {
+	console.error(
+		'Usage: npm run helper:install -- <extension-id> [brave|chrome|edge|chromium]',
+	);
+}
+
+function powershellPath() {
+	if (process.env.SystemRoot) {
+		return path.join(
+			process.env.SystemRoot,
+			'System32',
+			'WindowsPowerShell',
+			'v1.0',
+			'powershell.exe',
+		);
+	}
+
+	return 'powershell.exe';
+}
+
+function run(command, arguments_) {
+	const result = spawnSync(command, arguments_, {stdio: 'inherit'});
+	process.exit(result.status ?? 1);
+}
+
+if (!/^[a-p]{32}$/v.test(extensionId || '')) {
+	usage();
+	process.exit(2);
+}
+
+if (process.platform === 'darwin') {
+	run('bash', [
+		path.join(helperDirectory, 'install-macos.sh'),
+		extensionId,
+		browser,
+	]);
+}
+
+if (process.platform === 'win32') {
+	run(powershellPath(), [
+		'-NoProfile',
+		'-ExecutionPolicy',
+		'Bypass',
+		'-File',
+		path.join(helperDirectory, 'install-windows.ps1'),
+		'-ExtensionId',
+		extensionId,
+		'-Browser',
+		browser,
+	]);
+}
+
+console.error(
+	'The native popup helper installer supports macOS and Windows only.',
+);
+process.exit(1);

--- a/native-helper/native-clicker.m
+++ b/native-helper/native-clicker.m
@@ -1,0 +1,465 @@
+#import <ApplicationServices/ApplicationServices.h>
+#import <Cocoa/Cocoa.h>
+#include <unistd.h>
+
+static const uint32_t MaxNativeMessageLength = 1024 * 1024;
+
+static NSString *StringAttribute(AXUIElementRef element, CFStringRef attribute) {
+	CFTypeRef value = NULL;
+	if (AXUIElementCopyAttributeValue(element, attribute, &value) != kAXErrorSuccess || value == NULL) {
+		return @"";
+	}
+
+	NSString *result = @"";
+	if (CFGetTypeID(value) == CFStringGetTypeID()) {
+		result = [NSString stringWithString:(__bridge NSString *)value];
+	} else if (CFGetTypeID(value) == CFNumberGetTypeID()) {
+		result = [(__bridge NSNumber *)value stringValue];
+	} else {
+		result = [[(__bridge id)value description] ?: @"" copy];
+	}
+
+	CFRelease(value);
+	return result;
+}
+
+static NSArray *ChildrenOfElement(AXUIElementRef element) {
+	CFTypeRef value = NULL;
+	if (AXUIElementCopyAttributeValue(element, kAXChildrenAttribute, &value) != kAXErrorSuccess || value == NULL) {
+		return @[];
+	}
+
+	NSArray *children = CFGetTypeID(value) == CFArrayGetTypeID()
+		? [NSArray arrayWithArray:(__bridge NSArray *)value]
+		: @[];
+	CFRelease(value);
+	return children;
+}
+
+static BOOL ContainsTarget(AXUIElementRef element, NSString *target) {
+	NSMutableString *text = [NSMutableString string];
+	for (id attribute in @[
+		(__bridge NSString *)kAXDescriptionAttribute,
+		(__bridge NSString *)kAXTitleAttribute,
+		(__bridge NSString *)kAXValueAttribute,
+		(__bridge NSString *)kAXHelpAttribute,
+	]) {
+		NSString *part = StringAttribute(element, (__bridge CFStringRef)attribute);
+		if (part.length > 0) {
+			[text appendString:part];
+			[text appendString:@"\n"];
+		}
+	}
+
+	return [text rangeOfString:target options:NSCaseInsensitiveSearch | NSDiacriticInsensitiveSearch].location != NSNotFound;
+}
+
+static BOOL ClickElement(AXUIElementRef element) {
+	CFTypeRef positionValue = NULL;
+	CFTypeRef sizeValue = NULL;
+	if (
+		AXUIElementCopyAttributeValue(element, kAXPositionAttribute, &positionValue) == kAXErrorSuccess &&
+		AXUIElementCopyAttributeValue(element, kAXSizeAttribute, &sizeValue) == kAXErrorSuccess &&
+		positionValue != NULL &&
+		sizeValue != NULL
+	) {
+		CGPoint position;
+		CGSize size;
+		BOOL hasPosition = AXValueGetValue(positionValue, kAXValueCGPointType, &position);
+		BOOL hasSize = AXValueGetValue(sizeValue, kAXValueCGSizeType, &size);
+		CFRelease(positionValue);
+		CFRelease(sizeValue);
+
+		if (hasPosition && hasSize) {
+			CGPoint point = CGPointMake(position.x + (size.width / 2), position.y + (size.height / 2));
+			CGEventRef down = CGEventCreateMouseEvent(NULL, kCGEventLeftMouseDown, point, kCGMouseButtonLeft);
+			CGEventRef up = CGEventCreateMouseEvent(NULL, kCGEventLeftMouseUp, point, kCGMouseButtonLeft);
+			if (down != NULL && up != NULL) {
+				CGEventPost(kCGHIDEventTap, down);
+				usleep(80 * 1000);
+				CGEventPost(kCGHIDEventTap, up);
+				CFRelease(down);
+				CFRelease(up);
+				return YES;
+			}
+
+			if (down != NULL) {
+				CFRelease(down);
+			}
+
+			if (up != NULL) {
+				CFRelease(up);
+			}
+		}
+	} else {
+		if (positionValue != NULL) {
+			CFRelease(positionValue);
+		}
+
+		if (sizeValue != NULL) {
+			CFRelease(sizeValue);
+		}
+	}
+
+	return AXUIElementPerformAction(element, kAXPressAction) == kAXErrorSuccess;
+}
+
+static BOOL ClickToolbarItem(AXUIElementRef element, NSString *target, NSInteger depth, BOOL insideToolbar) {
+	if (depth > 12) {
+		return NO;
+	}
+
+	NSString *role = StringAttribute(element, kAXRoleAttribute);
+	BOOL nowInsideToolbar = insideToolbar || [role isEqualToString:@"AXToolbar"];
+	if (nowInsideToolbar && ContainsTarget(element, target) && ClickElement(element)) {
+		return YES;
+	}
+
+	for (id child in ChildrenOfElement(element)) {
+		if (ClickToolbarItem((__bridge AXUIElementRef)child, target, depth + 1, nowInsideToolbar)) {
+			return YES;
+		}
+	}
+
+	return NO;
+}
+
+static BOOL ClickTextItem(AXUIElementRef element, NSString *target, NSInteger depth) {
+	if (depth > 12) {
+		return NO;
+	}
+
+	if (ContainsTarget(element, target) && ClickElement(element)) {
+		return YES;
+	}
+
+	for (id child in ChildrenOfElement(element)) {
+		if (ClickTextItem((__bridge AXUIElementRef)child, target, depth + 1)) {
+			return YES;
+		}
+	}
+
+	return NO;
+}
+
+static NSArray *WindowsOfApplication(AXUIElementRef application) {
+	CFTypeRef value = NULL;
+	if (AXUIElementCopyAttributeValue(application, kAXWindowsAttribute, &value) != kAXErrorSuccess || value == NULL) {
+		return @[];
+	}
+
+	NSArray *windows = CFGetTypeID(value) == CFArrayGetTypeID()
+		? [NSArray arrayWithArray:(__bridge NSArray *)value]
+		: @[];
+	CFRelease(value);
+	return windows;
+}
+
+static pid_t FindApplicationPid(NSString *browserApp) {
+	for (NSRunningApplication *application in [[NSWorkspace sharedWorkspace] runningApplications]) {
+		if (
+			[[application localizedName] isEqualToString:browserApp] ||
+			([browserApp isEqualToString:@"Brave Browser"] && [[application bundleIdentifier] isEqualToString:@"com.brave.Browser"]) ||
+			([browserApp isEqualToString:@"Google Chrome"] && [[application bundleIdentifier] isEqualToString:@"com.google.Chrome"]) ||
+			([browserApp isEqualToString:@"Chromium"] && [[application bundleIdentifier] isEqualToString:@"org.chromium.Chromium"])
+		) {
+			return [application processIdentifier];
+		}
+	}
+
+	return -1;
+}
+
+static BOOL ClickAnyToolbarAlias(AXUIElementRef application, NSArray *targets) {
+	for (NSString *target in targets) {
+		for (id window in WindowsOfApplication(application)) {
+			if (ClickToolbarItem((__bridge AXUIElementRef)window, target, 0, NO)) {
+				return YES;
+			}
+		}
+	}
+
+	return NO;
+}
+
+static BOOL ClickAnyMenuAlias(AXUIElementRef application, NSArray *targets) {
+	NSArray *windows = WindowsOfApplication(application);
+	for (NSString *target in targets) {
+		for (id window in windows) {
+			NSString *subrole = StringAttribute((__bridge AXUIElementRef)window, kAXSubroleAttribute);
+			if (![subrole isEqualToString:@"AXStandardWindow"] && ClickTextItem((__bridge AXUIElementRef)window, target, 0)) {
+				return YES;
+			}
+		}
+	}
+
+	for (NSString *target in targets) {
+		for (id window in windows) {
+			if (ClickTextItem((__bridge AXUIElementRef)window, target, 0)) {
+				return YES;
+			}
+		}
+	}
+
+	return NO;
+}
+
+static BOOL IsTrusted(BOOL prompt) {
+	NSDictionary *options = @{(__bridge NSString *)kAXTrustedCheckOptionPrompt: @(prompt)};
+	return AXIsProcessTrustedWithOptions((__bridge CFDictionaryRef)options);
+}
+
+static NSString *OpenPopup(NSString *browserApp, NSArray *targets, NSString **errorMessage) {
+	pid_t pid = FindApplicationPid(browserApp);
+	if (pid <= 0) {
+		if (errorMessage != NULL) {
+			*errorMessage = [NSString stringWithFormat:@"Could not find running browser app: %@", browserApp];
+		}
+		return nil;
+	}
+
+	for (NSRunningApplication *application in [[NSWorkspace sharedWorkspace] runningApplications]) {
+		if ([application processIdentifier] == pid) {
+			[application activateWithOptions:0];
+			break;
+		}
+	}
+
+	usleep(200 * 1000);
+	AXUIElementRef application = AXUIElementCreateApplication(pid);
+	if (ClickAnyToolbarAlias(application, targets)) {
+		CFRelease(application);
+		return @"clicked pinned toolbar item";
+	}
+
+	if (ClickAnyToolbarAlias(application, @[@"Extensions"])) {
+		for (NSUInteger attempt = 0; attempt < 10; attempt++) {
+			usleep(150 * 1000);
+			if (ClickAnyMenuAlias(application, targets)) {
+				CFRelease(application);
+				return @"clicked extensions menu item";
+			}
+		}
+	}
+
+	CFRelease(application);
+	if (errorMessage != NULL) {
+		*errorMessage = @"Could not find the extension in the browser toolbar or Extensions menu.";
+	}
+	return nil;
+}
+
+static NSMutableData *ReadExact(int fileDescriptor, NSUInteger length) {
+	NSMutableData *data = [NSMutableData dataWithLength:length];
+	uint8_t *bytes = [data mutableBytes];
+	NSUInteger offset = 0;
+
+	while (offset < length) {
+		ssize_t bytesRead = read(fileDescriptor, bytes + offset, length - offset);
+		if (bytesRead <= 0) {
+			break;
+		}
+
+		offset += (NSUInteger)bytesRead;
+	}
+
+	if (offset < length) {
+		[data setLength:offset];
+	}
+
+	return data;
+}
+
+static int WriteNativeMessage(NSDictionary *message) {
+	NSError *error = nil;
+	NSData *body = [NSJSONSerialization dataWithJSONObject:message options:0 error:&error];
+	if (body == nil) {
+		return 1;
+	}
+
+	uint32_t length = (uint32_t)[body length];
+	uint8_t header[4] = {
+		(uint8_t)(length & 0xFF),
+		(uint8_t)((length >> 8) & 0xFF),
+		(uint8_t)((length >> 16) & 0xFF),
+		(uint8_t)((length >> 24) & 0xFF),
+	};
+
+	if (write(STDOUT_FILENO, header, sizeof(header)) != sizeof(header)) {
+		return 1;
+	}
+
+	if (write(STDOUT_FILENO, [body bytes], [body length]) != (ssize_t)[body length]) {
+		return 1;
+	}
+
+	return 0;
+}
+
+static BOOL IsValidExtensionId(NSString *extensionId) {
+	if (![extensionId isKindOfClass:[NSString class]] || [extensionId length] != 32) {
+		return NO;
+	}
+
+	for (NSUInteger index = 0; index < [extensionId length]; index++) {
+		unichar character = [extensionId characterAtIndex:index];
+		if (character < 'a' || character > 'p') {
+			return NO;
+		}
+	}
+
+	return YES;
+}
+
+static NSDictionary *ReadConfig(NSString *executablePath) {
+	NSString *configPath = [[executablePath stringByDeletingLastPathComponent] stringByAppendingPathComponent:@"native-host-config.json"];
+	NSData *data = [NSData dataWithContentsOfFile:configPath];
+	if (data == nil) {
+		return @{};
+	}
+
+	id config = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+	return [config isKindOfClass:[NSDictionary class]] ? config : @{};
+}
+
+static int RunNativeHost(NSString *executablePath) {
+	@try {
+		NSMutableData *header = ReadExact(STDIN_FILENO, 4);
+		if ([header length] < 4) {
+			return WriteNativeMessage(@{@"ok": @NO, @"error": @"Truncated native message header."});
+		}
+
+		const uint8_t *headerBytes = [header bytes];
+		uint32_t length =
+			(uint32_t)headerBytes[0] |
+			((uint32_t)headerBytes[1] << 8) |
+			((uint32_t)headerBytes[2] << 16) |
+			((uint32_t)headerBytes[3] << 24);
+		if (length > MaxNativeMessageLength) {
+			return WriteNativeMessage(@{@"ok": @NO, @"error": @"Native message body is too large."});
+		}
+
+		NSMutableData *body = ReadExact(STDIN_FILENO, length);
+		if ([body length] < length) {
+			return WriteNativeMessage(@{@"ok": @NO, @"error": @"Truncated native message body."});
+		}
+
+		id parsed = [NSJSONSerialization JSONObjectWithData:body options:0 error:nil];
+		if (![parsed isKindOfClass:[NSDictionary class]]) {
+			return WriteNativeMessage(@{@"ok": @NO, @"error": @"Invalid native helper request."});
+		}
+
+		NSDictionary *request = parsed;
+		NSString *type = request[@"type"];
+		NSString *extensionId = request[@"extensionId"];
+		NSString *extensionName = request[@"extensionName"];
+		id aliases = request[@"extensionAliases"];
+		if (![type isEqualToString:@"open-extension-popup"]) {
+			return WriteNativeMessage(@{@"ok": @NO, @"error": @"Unsupported native helper request type."});
+		}
+
+		if (!IsValidExtensionId(extensionId)) {
+			return WriteNativeMessage(@{@"ok": @NO, @"error": @"Invalid extension id."});
+		}
+
+		if (![extensionName isKindOfClass:[NSString class]] || [extensionName length] == 0) {
+			return WriteNativeMessage(@{@"ok": @NO, @"error": @"Invalid extension name."});
+		}
+
+		NSMutableArray *targets = [NSMutableArray arrayWithObject:extensionName];
+		if ([aliases isKindOfClass:[NSArray class]]) {
+			for (id alias in aliases) {
+				if ([alias isKindOfClass:[NSString class]] && [alias length] > 0) {
+					[targets addObject:alias];
+				}
+			}
+		}
+
+		if (!IsTrusted(YES)) {
+			return WriteNativeMessage(@{
+				@"ok": @NO,
+				@"error": @"Accessibility permission is required. Grant access to native-host in System Settings > Privacy & Security > Accessibility, then try again.",
+			});
+		}
+
+		NSDictionary *config = ReadConfig(executablePath);
+		NSString *browserApp = [config[@"browserApp"] isKindOfClass:[NSString class]]
+			? config[@"browserApp"]
+			: @"Brave Browser";
+		NSString *errorMessage = nil;
+		NSString *detail = OpenPopup(browserApp, targets, &errorMessage);
+		if (detail == nil) {
+			return WriteNativeMessage(@{@"ok": @NO, @"error": errorMessage ?: @"Native host failed."});
+		}
+
+		return WriteNativeMessage(@{@"ok": @YES, @"detail": detail});
+	} @catch (NSException *exception) {
+		return WriteNativeMessage(@{@"ok": @NO, @"error": [exception reason] ?: @"Native host failed."});
+	}
+}
+
+int main(int argc, const char *argv[]) {
+	@autoreleasepool {
+		NSString *executablePath = [[NSFileManager defaultManager] stringWithFileSystemRepresentation:argv[0] length:strlen(argv[0])];
+		NSString *executableName = [executablePath lastPathComponent];
+		if (argc == 2 && strcmp(argv[1], "--check") == 0) {
+			BOOL trusted = IsTrusted(NO);
+			printf("%s\n", trusted ? "trusted" : "not trusted");
+			return trusted ? 0 : 3;
+		}
+
+		if (argc == 2 && strcmp(argv[1], "--prompt") == 0) {
+			BOOL trusted = IsTrusted(YES);
+			printf("%s\n", trusted ? "trusted" : "not trusted");
+			return trusted ? 0 : 3;
+		}
+
+		if ([executableName isEqualToString:@"native-host"] || (argc == 2 && strcmp(argv[1], "--native-host") == 0)) {
+			return RunNativeHost(executablePath);
+		}
+
+		if (argc != 3) {
+			fprintf(stderr, "Usage: native-clicker <browser-app> '<json-name-array>'\n");
+			return 2;
+		}
+
+		if (!IsTrusted(YES)) {
+			fprintf(
+				stderr,
+				"Accessibility permission is required. Grant access to native-clicker in System Settings > Privacy & Security > Accessibility, then try again.\n"
+			);
+			return 3;
+		}
+
+		NSString *browserApp = [NSString stringWithUTF8String:argv[1]];
+		NSData *jsonData = [[NSString stringWithUTF8String:argv[2]] dataUsingEncoding:NSUTF8StringEncoding];
+		NSError *jsonError = nil;
+		id parsed = [NSJSONSerialization JSONObjectWithData:jsonData options:0 error:&jsonError];
+		if (![parsed isKindOfClass:[NSArray class]]) {
+			fprintf(stderr, "Invalid target name array.\n");
+			return 2;
+		}
+
+		NSMutableArray *targets = [NSMutableArray array];
+		for (id value in (NSArray *)parsed) {
+			if ([value isKindOfClass:[NSString class]] && [value length] > 0) {
+				[targets addObject:value];
+			}
+		}
+
+		if (targets.count == 0) {
+			fprintf(stderr, "No target names were provided.\n");
+			return 2;
+		}
+
+		NSString *errorMessage = nil;
+		NSString *detail = OpenPopup(browserApp, targets, &errorMessage);
+		if (detail != nil) {
+			printf("%s\n", [detail UTF8String]);
+			return 0;
+		}
+
+		fprintf(stderr, "%s\n", [errorMessage UTF8String]);
+		return 5;
+	}
+}

--- a/native-helper/native-clicker.m
+++ b/native-helper/native-clicker.m
@@ -104,6 +104,59 @@ static BOOL ClickElement(AXUIElementRef element) {
 	return AXUIElementPerformAction(element, kAXPressAction) == kAXErrorSuccess;
 }
 
+static BOOL ScrollElement(AXUIElementRef element, int32_t delta) {
+	CFTypeRef positionValue = NULL;
+	CFTypeRef sizeValue = NULL;
+	if (
+		AXUIElementCopyAttributeValue(element, kAXPositionAttribute, &positionValue) != kAXErrorSuccess ||
+		AXUIElementCopyAttributeValue(element, kAXSizeAttribute, &sizeValue) != kAXErrorSuccess ||
+		positionValue == NULL ||
+		sizeValue == NULL
+	) {
+		if (positionValue != NULL) {
+			CFRelease(positionValue);
+		}
+
+		if (sizeValue != NULL) {
+			CFRelease(sizeValue);
+		}
+
+		return NO;
+	}
+
+	CGPoint position;
+	CGSize size;
+	BOOL hasPosition = AXValueGetValue(positionValue, kAXValueCGPointType, &position);
+	BOOL hasSize = AXValueGetValue(sizeValue, kAXValueCGSizeType, &size);
+	CFRelease(positionValue);
+	CFRelease(sizeValue);
+	if (!hasPosition || !hasSize) {
+		return NO;
+	}
+
+	CGPoint point = CGPointMake(position.x + (size.width / 2), position.y + (size.height / 2));
+	CGEventRef move = CGEventCreateMouseEvent(NULL, kCGEventMouseMoved, point, kCGMouseButtonLeft);
+	CGEventRef scroll = CGEventCreateScrollWheelEvent(NULL, kCGScrollEventUnitLine, 1, delta);
+	if (move == NULL || scroll == NULL) {
+		if (move != NULL) {
+			CFRelease(move);
+		}
+
+		if (scroll != NULL) {
+			CFRelease(scroll);
+		}
+
+		return NO;
+	}
+
+	CGEventPost(kCGHIDEventTap, move);
+	usleep(30 * 1000);
+	CGEventPost(kCGHIDEventTap, scroll);
+	CFRelease(move);
+	CFRelease(scroll);
+	return YES;
+}
+
 static BOOL ClickToolbarItem(AXUIElementRef element, NSString *target, NSInteger depth, BOOL insideToolbar) {
 	if (depth > 12) {
 		return NO;
@@ -197,6 +250,45 @@ static BOOL ClickAnyMenuAlias(AXUIElementRef application, NSArray *targets) {
 		for (id window in windows) {
 			if (ClickTextItem((__bridge AXUIElementRef)window, target, 0)) {
 				return YES;
+			}
+		}
+	}
+
+	for (NSUInteger attempt = 0; attempt < 8; attempt++) {
+		BOOL scrolled = NO;
+		for (id window in windows) {
+			NSString *subrole = StringAttribute((__bridge AXUIElementRef)window, kAXSubroleAttribute);
+			if (![subrole isEqualToString:@"AXStandardWindow"]) {
+				scrolled = ScrollElement((__bridge AXUIElementRef)window, -8) || scrolled;
+			}
+		}
+
+		if (!scrolled) {
+			for (id window in windows) {
+				scrolled = ScrollElement((__bridge AXUIElementRef)window, -8) || scrolled;
+			}
+		}
+
+		if (!scrolled) {
+			break;
+		}
+
+		usleep(120 * 1000);
+		windows = WindowsOfApplication(application);
+		for (NSString *target in targets) {
+			for (id window in windows) {
+				NSString *subrole = StringAttribute((__bridge AXUIElementRef)window, kAXSubroleAttribute);
+				if (![subrole isEqualToString:@"AXStandardWindow"] && ClickTextItem((__bridge AXUIElementRef)window, target, 0)) {
+					return YES;
+				}
+			}
+		}
+
+		for (NSString *target in targets) {
+			for (id window in windows) {
+				if (ClickTextItem((__bridge AXUIElementRef)window, target, 0)) {
+					return YES;
+				}
 			}
 		}
 	}
@@ -375,7 +467,7 @@ static int RunNativeHost(NSString *executablePath) {
 			}
 		}
 
-		if (!IsTrusted(YES)) {
+		if (!IsTrusted(NO)) {
 			return WriteNativeMessage(@{
 				@"ok": @NO,
 				@"error": @"Accessibility permission is required. Grant access to native-host in System Settings > Privacy & Security > Accessibility, then try again.",
@@ -423,7 +515,7 @@ int main(int argc, const char *argv[]) {
 			return 2;
 		}
 
-		if (!IsTrusted(YES)) {
+		if (!IsTrusted(NO)) {
 			fprintf(
 				stderr,
 				"Accessibility permission is required. Grant access to native-clicker in System Settings > Privacy & Security > Accessibility, then try again.\n"

--- a/native-helper/native-clicker.m
+++ b/native-helper/native-clicker.m
@@ -54,6 +54,54 @@ static BOOL ContainsTarget(AXUIElementRef element, NSString *target) {
 	return [text rangeOfString:target options:NSCaseInsensitiveSearch | NSDiacriticInsensitiveSearch].location != NSNotFound;
 }
 
+static NSString *ElementText(AXUIElementRef element) {
+	NSMutableString *text = [NSMutableString string];
+	for (id attribute in @[
+		(__bridge NSString *)kAXDescriptionAttribute,
+		(__bridge NSString *)kAXTitleAttribute,
+		(__bridge NSString *)kAXValueAttribute,
+		(__bridge NSString *)kAXHelpAttribute,
+	]) {
+		NSString *part = StringAttribute(element, (__bridge CFStringRef)attribute);
+		if (part.length > 0) {
+			[text appendString:part];
+			[text appendString:@"\n"];
+		}
+	}
+
+	return [text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+}
+
+static BOOL IsMenuExtensionActionButton(AXUIElementRef element) {
+	NSString *role = StringAttribute(element, kAXRoleAttribute);
+	if (![role isEqualToString:@"AXButton"]) {
+		return NO;
+	}
+
+	NSString *text = ElementText(element);
+	return !(
+		[text hasPrefix:@"Pin "] ||
+		[text hasPrefix:@"Unpin "] ||
+		[text hasPrefix:@"More options for "]
+	);
+}
+
+static BOOL HasExactTargetAttribute(AXUIElementRef element, NSString *target) {
+	for (id attribute in @[
+		(__bridge NSString *)kAXDescriptionAttribute,
+		(__bridge NSString *)kAXTitleAttribute,
+		(__bridge NSString *)kAXValueAttribute,
+		(__bridge NSString *)kAXHelpAttribute,
+	]) {
+		NSString *part = [StringAttribute(element, (__bridge CFStringRef)attribute) stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+		if ([part compare:target options:NSCaseInsensitiveSearch | NSDiacriticInsensitiveSearch] == NSOrderedSame) {
+			return YES;
+		}
+	}
+
+	return NO;
+}
+
 static BOOL ClickElement(AXUIElementRef element) {
 	CFTypeRef positionValue = NULL;
 	CFTypeRef sizeValue = NULL;
@@ -102,6 +150,15 @@ static BOOL ClickElement(AXUIElementRef element) {
 	}
 
 	return AXUIElementPerformAction(element, kAXPressAction) == kAXErrorSuccess;
+}
+
+static BOOL IsToolbarControl(AXUIElementRef element) {
+	NSString *role = StringAttribute(element, kAXRoleAttribute);
+	NSString *subrole = StringAttribute(element, kAXSubroleAttribute);
+	return (
+		([role isEqualToString:@"AXButton"] || [role isEqualToString:@"AXPopUpButton"] || [role isEqualToString:@"AXMenuButton"]) &&
+		![subrole isEqualToString:@"AXTabButton"]
+	);
 }
 
 static BOOL ScrollElement(AXUIElementRef element, int32_t delta) {
@@ -157,6 +214,24 @@ static BOOL ScrollElement(AXUIElementRef element, int32_t delta) {
 	return YES;
 }
 
+static void PressEscapeKey(void) {
+	CGEventRef down = CGEventCreateKeyboardEvent(NULL, (CGKeyCode)53, true);
+	CGEventRef up = CGEventCreateKeyboardEvent(NULL, (CGKeyCode)53, false);
+	if (down != NULL && up != NULL) {
+		CGEventPost(kCGHIDEventTap, down);
+		usleep(40 * 1000);
+		CGEventPost(kCGHIDEventTap, up);
+	}
+
+	if (down != NULL) {
+		CFRelease(down);
+	}
+
+	if (up != NULL) {
+		CFRelease(up);
+	}
+}
+
 static BOOL ClickToolbarItem(AXUIElementRef element, NSString *target, NSInteger depth, BOOL insideToolbar) {
 	if (depth > 12) {
 		return NO;
@@ -164,7 +239,10 @@ static BOOL ClickToolbarItem(AXUIElementRef element, NSString *target, NSInteger
 
 	NSString *role = StringAttribute(element, kAXRoleAttribute);
 	BOOL nowInsideToolbar = insideToolbar || [role isEqualToString:@"AXToolbar"];
-	if (nowInsideToolbar && ContainsTarget(element, target) && ClickElement(element)) {
+	BOOL targetMatches = [target isEqualToString:@"Extensions"]
+		? HasExactTargetAttribute(element, target)
+		: ContainsTarget(element, target);
+	if (nowInsideToolbar && IsToolbarControl(element) && targetMatches && ClickElement(element)) {
 		return YES;
 	}
 
@@ -182,12 +260,30 @@ static BOOL ClickTextItem(AXUIElementRef element, NSString *target, NSInteger de
 		return NO;
 	}
 
-	if (ContainsTarget(element, target) && ClickElement(element)) {
+	for (id child in ChildrenOfElement(element)) {
+		if (ClickTextItem((__bridge AXUIElementRef)child, target, depth + 1)) {
+			return YES;
+		}
+	}
+
+	if (IsMenuExtensionActionButton(element) && ContainsTarget(element, target) && ClickElement(element)) {
+		return YES;
+	}
+
+	return NO;
+}
+
+static BOOL TreeContainsTarget(AXUIElementRef element, NSString *target, NSInteger depth) {
+	if (depth > 12) {
+		return NO;
+	}
+
+	if (ContainsTarget(element, target)) {
 		return YES;
 	}
 
 	for (id child in ChildrenOfElement(element)) {
-		if (ClickTextItem((__bridge AXUIElementRef)child, target, depth + 1)) {
+		if (TreeContainsTarget((__bridge AXUIElementRef)child, target, depth + 1)) {
 			return YES;
 		}
 	}
@@ -244,7 +340,10 @@ static NSArray *MenuWindowsOfApplication(AXUIElementRef application) {
 	NSMutableArray *menuWindows = [NSMutableArray array];
 	for (id window in WindowsOfApplication(application)) {
 		NSString *subrole = StringAttribute((__bridge AXUIElementRef)window, kAXSubroleAttribute);
-		if (![subrole isEqualToString:@"AXStandardWindow"]) {
+		if (
+			![subrole isEqualToString:@"AXStandardWindow"] &&
+			TreeContainsTarget((__bridge AXUIElementRef)window, @"Manage Extensions", 0)
+		) {
 			[menuWindows addObject:window];
 		}
 	}
@@ -318,11 +417,8 @@ static NSString *OpenPopup(NSString *browserApp, NSArray *targets, NSString **er
 		return @"clicked pinned toolbar item";
 	}
 
-	if (ClickAnyMenuAlias(application, targets)) {
-		CFRelease(application);
-		return @"clicked existing extensions menu item";
-	}
-
+	PressEscapeKey();
+	usleep(180 * 1000);
 	if (ClickAnyToolbarAlias(application, @[@"Extensions"])) {
 		for (NSUInteger attempt = 0; attempt < 10; attempt++) {
 			usleep(150 * 1000);

--- a/native-helper/native-clicker.m
+++ b/native-helper/native-clicker.m
@@ -226,6 +226,11 @@ static pid_t FindApplicationPid(NSString *browserApp) {
 static BOOL ClickAnyToolbarAlias(AXUIElementRef application, NSArray *targets) {
 	for (NSString *target in targets) {
 		for (id window in WindowsOfApplication(application)) {
+			NSString *subrole = StringAttribute((__bridge AXUIElementRef)window, kAXSubroleAttribute);
+			if (![subrole isEqualToString:@"AXStandardWindow"]) {
+				continue;
+			}
+
 			if (ClickToolbarItem((__bridge AXUIElementRef)window, target, 0, NO)) {
 				return YES;
 			}
@@ -235,15 +240,22 @@ static BOOL ClickAnyToolbarAlias(AXUIElementRef application, NSArray *targets) {
 	return NO;
 }
 
-static BOOL ClickAnyMenuAlias(AXUIElementRef application, NSArray *targets) {
-	NSArray *windows = WindowsOfApplication(application);
-	for (NSString *target in targets) {
-		for (id window in windows) {
-			NSString *subrole = StringAttribute((__bridge AXUIElementRef)window, kAXSubroleAttribute);
-			if (![subrole isEqualToString:@"AXStandardWindow"] && ClickTextItem((__bridge AXUIElementRef)window, target, 0)) {
-				return YES;
-			}
+static NSArray *MenuWindowsOfApplication(AXUIElementRef application) {
+	NSMutableArray *menuWindows = [NSMutableArray array];
+	for (id window in WindowsOfApplication(application)) {
+		NSString *subrole = StringAttribute((__bridge AXUIElementRef)window, kAXSubroleAttribute);
+		if (![subrole isEqualToString:@"AXStandardWindow"]) {
+			[menuWindows addObject:window];
 		}
+	}
+
+	return menuWindows;
+}
+
+static BOOL ClickAnyMenuAlias(AXUIElementRef application, NSArray *targets) {
+	NSArray *windows = MenuWindowsOfApplication(application);
+	if ([windows count] == 0) {
+		return NO;
 	}
 
 	for (NSString *target in targets) {
@@ -254,19 +266,10 @@ static BOOL ClickAnyMenuAlias(AXUIElementRef application, NSArray *targets) {
 		}
 	}
 
-	for (NSUInteger attempt = 0; attempt < 8; attempt++) {
+	for (NSUInteger attempt = 0; attempt < 5; attempt++) {
 		BOOL scrolled = NO;
 		for (id window in windows) {
-			NSString *subrole = StringAttribute((__bridge AXUIElementRef)window, kAXSubroleAttribute);
-			if (![subrole isEqualToString:@"AXStandardWindow"]) {
-				scrolled = ScrollElement((__bridge AXUIElementRef)window, -8) || scrolled;
-			}
-		}
-
-		if (!scrolled) {
-			for (id window in windows) {
-				scrolled = ScrollElement((__bridge AXUIElementRef)window, -8) || scrolled;
-			}
+			scrolled = ScrollElement((__bridge AXUIElementRef)window, -8) || scrolled;
 		}
 
 		if (!scrolled) {
@@ -274,16 +277,7 @@ static BOOL ClickAnyMenuAlias(AXUIElementRef application, NSArray *targets) {
 		}
 
 		usleep(120 * 1000);
-		windows = WindowsOfApplication(application);
-		for (NSString *target in targets) {
-			for (id window in windows) {
-				NSString *subrole = StringAttribute((__bridge AXUIElementRef)window, kAXSubroleAttribute);
-				if (![subrole isEqualToString:@"AXStandardWindow"] && ClickTextItem((__bridge AXUIElementRef)window, target, 0)) {
-					return YES;
-				}
-			}
-		}
-
+		windows = MenuWindowsOfApplication(application);
 		for (NSString *target in targets) {
 			for (id window in windows) {
 				if (ClickTextItem((__bridge AXUIElementRef)window, target, 0)) {
@@ -322,6 +316,11 @@ static NSString *OpenPopup(NSString *browserApp, NSArray *targets, NSString **er
 	if (ClickAnyToolbarAlias(application, targets)) {
 		CFRelease(application);
 		return @"clicked pinned toolbar item";
+	}
+
+	if (ClickAnyMenuAlias(application, targets)) {
+		CFRelease(application);
+		return @"clicked existing extensions menu item";
 	}
 
 	if (ClickAnyToolbarAlias(application, @[@"Extensions"])) {

--- a/native-helper/native-host-launcher.c
+++ b/native-helper/native-host-launcher.c
@@ -1,0 +1,38 @@
+#include <mach-o/dyld.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#ifndef OCEM_NODE_BIN
+#define OCEM_NODE_BIN "/usr/bin/node"
+#endif
+
+int main(void) {
+	char executable_path[PATH_MAX];
+	uint32_t size = sizeof(executable_path);
+
+	if (_NSGetExecutablePath(executable_path, &size) != 0) {
+		fprintf(stderr, "native-host path is too long\n");
+		return 1;
+	}
+
+	char *slash = strrchr(executable_path, '/');
+	if (slash == NULL) {
+		fprintf(stderr, "native-host path is invalid\n");
+		return 1;
+	}
+
+	*slash = '\0';
+
+	char script_path[PATH_MAX];
+	if (snprintf(script_path, sizeof(script_path), "%s/native-host.mjs", executable_path) >= (int)sizeof(script_path)) {
+		fprintf(stderr, "native-host script path is too long\n");
+		return 1;
+	}
+
+	char *const argv[] = {OCEM_NODE_BIN, script_path, NULL};
+	execv(OCEM_NODE_BIN, argv);
+	perror("execv");
+	return 1;
+}

--- a/native-helper/native-host.mjs
+++ b/native-helper/native-host.mjs
@@ -35,7 +35,61 @@ export function validateRequest(request) {
 	}
 }
 
-export function readNativeMessage(input = fs.readFileSync(0)) {
+function sleepSync(milliseconds) {
+	Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
+function readExactBytes(fileDescriptor, length) {
+	const buffer = Buffer.alloc(length);
+	let offset = 0;
+	const deadline = Date.now() + 5000;
+
+	while (offset < length) {
+		try {
+			const bytesRead = fs.readSync(
+				fileDescriptor,
+				buffer,
+				offset,
+				length - offset,
+				null,
+			);
+			if (bytesRead === 0) {
+				break;
+			}
+
+			offset += bytesRead;
+		} catch (error) {
+			if (error.code !== 'EAGAIN' || Date.now() > deadline) {
+				throw error;
+			}
+
+			sleepSync(10);
+		}
+	}
+
+	return buffer.subarray(0, offset);
+}
+
+function readNativeMessageFromStdin() {
+	const header = readExactBytes(0, 4);
+	if (header.length < 4) {
+		throw new Error('Truncated native message header.');
+	}
+
+	const length = header.readUInt32LE(0);
+	const body = readExactBytes(0, length);
+	if (body.length < length) {
+		throw new Error('Truncated native message body.');
+	}
+
+	return JSON.parse(body.toString('utf8'));
+}
+
+export function readNativeMessage(input) {
+	if (input === undefined) {
+		return readNativeMessageFromStdin();
+	}
+
 	if (input.length < 4) {
 		throw new Error('Truncated native message header.');
 	}

--- a/native-helper/native-host.mjs
+++ b/native-helper/native-host.mjs
@@ -67,50 +67,79 @@ function runAppleScript({browserApp, extensionName}) {
 	const script = `
 set targetName to ${appleScriptString(extensionName)}
 
-on clickByDescription(rootElement, depth, wantedText)
-	if depth > 9 then return false
+on pressElement(rootElement)
+	tell application "System Events"
+		try
+			set itemPosition to position of rootElement
+			set itemSize to size of rootElement
+			click at {((item 1 of itemPosition) + ((item 1 of itemSize) / 2)), ((item 2 of itemPosition) + ((item 2 of itemSize) / 2))}
+			return true
+		end try
+		try
+			click rootElement
+			return true
+		end try
+		try
+			perform action "AXPress" of rootElement
+			return true
+		end try
+	end tell
+	return false
+end pressElement
+
+on clickToolbarItemByDescription(rootElement, depth, wantedText, insideToolbar)
+	if depth > 12 then return false
 	set wantedString to wantedText as text
 	tell application "System Events"
+		set roleText to ""
+		try
+			set roleText to role of rootElement as text
+		end try
+		set nowInsideToolbar to insideToolbar
+		if roleText is "AXToolbar" then set nowInsideToolbar to true
 		try
 			set descriptionText to description of rootElement as text
 		on error
 			set descriptionText to ""
 		end try
-		ignoring case
-			if descriptionText contains wantedString then
-				try
-					click rootElement
-					return true
-				on error
-					try
-						set itemPosition to position of rootElement
-						set itemSize to size of rootElement
-						click at {((item 1 of itemPosition) + ((item 1 of itemSize) / 2)), ((item 2 of itemPosition) + ((item 2 of itemSize) / 2))}
-						return true
-					end try
-				end try
-			end if
-		end ignoring
+		if nowInsideToolbar then
+			ignoring case
+				if descriptionText contains wantedString then
+					if my pressElement(rootElement) then return true
+				end if
+			end ignoring
+		end if
 		try
 			repeat with child in UI elements of rootElement
-				if my clickByDescription(child, depth + 1, wantedString) then return true
+				if my clickToolbarItemByDescription(child, depth + 1, wantedString, nowInsideToolbar) then return true
 			end repeat
 		end try
 	end tell
 	return false
-end clickByDescription
+end clickToolbarItemByDescription
+
+on clickToolbarItemInAnyWindow(wantedText)
+	tell application "System Events"
+		tell process ${appleScriptString(browserApp)}
+			repeat with browserWindow in windows
+				if my clickToolbarItemByDescription(browserWindow, 0, wantedText, false) then return true
+			end repeat
+		end tell
+	end tell
+	return false
+end clickToolbarItemInAnyWindow
 
 tell application ${appleScriptString(browserApp)} to activate
 delay 0.2
 tell application "System Events"
 	tell process ${appleScriptString(browserApp)}
 		set frontmost to true
-		if my clickByDescription(front window, 0, targetName) then
+		if my clickToolbarItemInAnyWindow(targetName) then
 			return "clicked pinned toolbar item"
 		end if
-		if my clickByDescription(front window, 0, "Extensions") then
+		if my clickToolbarItemInAnyWindow("Extensions") then
 			delay 0.4
-			if my clickByDescription(front window, 0, targetName) then
+			if my clickToolbarItemInAnyWindow(targetName) then
 				return "clicked extensions menu item"
 			end if
 		end if

--- a/native-helper/native-host.mjs
+++ b/native-helper/native-host.mjs
@@ -122,6 +122,14 @@ function appleScriptList(values) {
 	return `{${values.map(value => appleScriptString(value)).join(', ')}}`;
 }
 
+function powerShellString(value) {
+	return `'${String(value).replaceAll("'", "''")}'`;
+}
+
+function powerShellList(values) {
+	return `@(${values.map(value => powerShellString(value)).join(', ')})`;
+}
+
 function sanitizeAutomationError(error) {
 	return String(error)
 		.replaceAll(configPath, '<config>')
@@ -150,10 +158,14 @@ function runNativeClicker({browserApp, extensionNames}) {
 		throw new Error('Native clicker is not installed.');
 	}
 
-	const result = spawnSync(clickerPath, [browserApp, JSON.stringify(extensionNames)], {
-		encoding: 'utf8',
-		timeout: 8000,
-	});
+	const result = spawnSync(
+		clickerPath,
+		[browserApp, JSON.stringify(extensionNames)],
+		{
+			encoding: 'utf8',
+			timeout: 8000,
+		},
+	);
 
 	if (result.status !== 0) {
 		throw new Error(
@@ -333,17 +345,307 @@ error "Could not find the extension in the browser toolbar or Extensions menu."
 	return result.stdout.trim() || 'clicked extension popup';
 }
 
-export function openExtensionPopup(request, config = readConfig()) {
-	validateRequest(request);
-	if (process.platform !== 'darwin') {
-		throw new Error('The native popup helper currently supports macOS only.');
+export function browserProcessNamesFromConfig(config = {}) {
+	if (Array.isArray(config.browserProcessNames)) {
+		const configuredNames = uniqueNames(
+			config.browserProcessNames
+				.filter(name => typeof name === 'string')
+				.map(name => name.replace(/\.exe$/iv, '')),
+		);
+		if (configuredNames.length > 0) {
+			return configuredNames;
+		}
 	}
 
-	const browserApp = config.browserApp || 'Brave Browser';
+	const browserName = String(
+		config.browser || config.browserApp || config.browserDisplayName || '',
+	).toLowerCase();
+
+	if (browserName.includes('chrome')) {
+		return ['chrome'];
+	}
+
+	if (browserName.includes('edge')) {
+		return ['msedge'];
+	}
+
+	if (browserName.includes('chromium')) {
+		return ['chromium'];
+	}
+
+	return ['brave'];
+}
+
+function windowsPowerShellPath() {
+	if (!process.env.SystemRoot) {
+		return 'powershell.exe';
+	}
+
+	return path.join(
+		process.env.SystemRoot,
+		'System32',
+		'WindowsPowerShell',
+		'v1.0',
+		'powershell.exe',
+	);
+}
+
+export function buildWindowsAutomationScript({
+	browserProcessNames,
+	extensionNames,
+}) {
+	return `
+$ErrorActionPreference = 'Stop'
+$targetNames = ${powerShellList(extensionNames)}
+$browserProcessNames = ${powerShellList(browserProcessNames)}
+
+Add-Type -AssemblyName UIAutomationClient
+Add-Type -AssemblyName UIAutomationTypes
+Add-Type @'
+using System;
+using System.Runtime.InteropServices;
+
+public static class OnFireNativeWindow {
+	[DllImport("user32.dll")]
+	public static extern bool SetForegroundWindow(IntPtr hWnd);
+
+	[DllImport("user32.dll")]
+	public static extern bool ShowWindowAsync(IntPtr hWnd, int nCmdShow);
+
+	[DllImport("user32.dll")]
+	public static extern bool SetCursorPos(int x, int y);
+
+	[DllImport("user32.dll")]
+	public static extern void mouse_event(int flags, int dx, int dy, int data, UIntPtr extraInfo);
+}
+'@
+
+function Find-BrowserProcess {
+	foreach ($processName in $browserProcessNames) {
+		$processes = Get-Process -Name $processName -ErrorAction SilentlyContinue |
+			Where-Object { $_.MainWindowHandle -ne 0 } |
+			Sort-Object StartTime -Descending
+		if ($processes) {
+			return $processes[0]
+		}
+	}
+
+	return $null
+}
+
+function Test-NameMatch($value, $names) {
+	if ([string]::IsNullOrWhiteSpace($value)) {
+		return $false
+	}
+
+	foreach ($name in $names) {
+		if ($value.IndexOf($name, [StringComparison]::OrdinalIgnoreCase) -ge 0) {
+			return $true
+		}
+	}
+
+	return $false
+}
+
+function Invoke-OnFireElement($element) {
+	try {
+		$invokePattern = $element.GetCurrentPattern([System.Windows.Automation.InvokePattern]::Pattern)
+		if ($invokePattern) {
+			$invokePattern.Invoke()
+			return $true
+		}
+	} catch {}
+
+	try {
+		$expandPattern = $element.GetCurrentPattern([System.Windows.Automation.ExpandCollapsePattern]::Pattern)
+		if ($expandPattern) {
+			$expandPattern.Expand()
+			return $true
+		}
+	} catch {}
+
+	try {
+		$rectangle = $element.Current.BoundingRectangle
+		if (-not $rectangle.IsEmpty) {
+			$x = [int]($rectangle.Left + ($rectangle.Width / 2))
+			$y = [int]($rectangle.Top + ($rectangle.Height / 2))
+			[OnFireNativeWindow]::SetCursorPos($x, $y) | Out-Null
+			[OnFireNativeWindow]::mouse_event(0x0002, 0, 0, 0, [UIntPtr]::Zero)
+			[OnFireNativeWindow]::mouse_event(0x0004, 0, 0, 0, [UIntPtr]::Zero)
+			return $true
+		}
+	} catch {}
+
+	return $false
+}
+
+function Find-MatchingElement($roots, $names, $maxDepth) {
+	$queue = New-Object System.Collections.Queue
+	foreach ($root in $roots) {
+		if ($root) {
+			$queue.Enqueue([pscustomobject]@{ Element = $root; Depth = 0 })
+		}
+	}
+
+	while ($queue.Count -gt 0) {
+		$item = $queue.Dequeue()
+		$element = $item.Element
+		$depth = $item.Depth
+		try {
+			if (Test-NameMatch $element.Current.Name $names) {
+				return $element
+			}
+		} catch {}
+
+		if ($depth -ge $maxDepth) {
+			continue
+		}
+
+		try {
+			$children = $element.FindAll(
+				[System.Windows.Automation.TreeScope]::Children,
+				[System.Windows.Automation.Condition]::TrueCondition
+			)
+			foreach ($child in $children) {
+				$queue.Enqueue([pscustomobject]@{ Element = $child; Depth = $depth + 1 })
+			}
+		} catch {}
+	}
+
+	return $null
+}
+
+function Find-ToolbarRoots($root) {
+	$toolbars = New-Object System.Collections.ArrayList
+	$queue = New-Object System.Collections.Queue
+	$queue.Enqueue([pscustomobject]@{ Element = $root; Depth = 0 })
+	while ($queue.Count -gt 0) {
+		$item = $queue.Dequeue()
+		$element = $item.Element
+		$depth = $item.Depth
+		try {
+			if ($element.Current.ControlType -eq [System.Windows.Automation.ControlType]::ToolBar) {
+				[void]$toolbars.Add($element)
+			}
+		} catch {}
+
+		if ($depth -ge 8) {
+			continue
+		}
+
+		try {
+			$children = $element.FindAll(
+				[System.Windows.Automation.TreeScope]::Children,
+				[System.Windows.Automation.Condition]::TrueCondition
+			)
+			foreach ($child in $children) {
+				$queue.Enqueue([pscustomobject]@{ Element = $child; Depth = $depth + 1 })
+			}
+		} catch {}
+	}
+
+	return $toolbars
+}
+
+function Get-PopupRoots($browserHandle) {
+	$roots = New-Object System.Collections.ArrayList
+	$desktop = [System.Windows.Automation.AutomationElement]::RootElement
+	$children = $desktop.FindAll(
+		[System.Windows.Automation.TreeScope]::Children,
+		[System.Windows.Automation.Condition]::TrueCondition
+	)
+	foreach ($child in $children) {
+		try {
+			if ($child.Current.NativeWindowHandle -ne $browserHandle) {
+				[void]$roots.Add($child)
+			}
+		} catch {}
+	}
+
+	return $roots
+}
+
+$browserProcess = Find-BrowserProcess
+if (-not $browserProcess) {
+	throw 'Could not find a running supported browser window.'
+}
+
+$browserHandle = $browserProcess.MainWindowHandle
+[OnFireNativeWindow]::ShowWindowAsync($browserHandle, 9) | Out-Null
+[OnFireNativeWindow]::SetForegroundWindow($browserHandle) | Out-Null
+Start-Sleep -Milliseconds 250
+
+$browserRoot = [System.Windows.Automation.AutomationElement]::FromHandle($browserHandle)
+$toolbarRoots = Find-ToolbarRoots $browserRoot
+
+$pinnedElement = Find-MatchingElement $toolbarRoots $targetNames 8
+if ($pinnedElement -and (Invoke-OnFireElement $pinnedElement)) {
+	'clicked pinned toolbar item'
+	exit 0
+}
+
+$extensionsButton = Find-MatchingElement $toolbarRoots @('Extensions') 8
+if ($extensionsButton -and (Invoke-OnFireElement $extensionsButton)) {
+	Start-Sleep -Milliseconds 650
+	$popupElement = Find-MatchingElement (Get-PopupRoots $browserHandle) $targetNames 12
+	if ($popupElement -and (Invoke-OnFireElement $popupElement)) {
+		'clicked extensions menu item'
+		exit 0
+	}
+}
+
+throw 'Could not find the extension in the browser toolbar or Extensions menu.'
+`;
+}
+
+function runWindowsAutomation({browserProcessNames, extensionNames}) {
+	const result = spawnSync(
+		windowsPowerShellPath(),
+		[
+			'-NoProfile',
+			'-NonInteractive',
+			'-ExecutionPolicy',
+			'Bypass',
+			'-Command',
+			buildWindowsAutomationScript({browserProcessNames, extensionNames}),
+		],
+		{
+			encoding: 'utf8',
+			timeout: 10_000,
+			windowsHide: true,
+		},
+	);
+
+	if (result.status !== 0) {
+		throw new Error(
+			sanitizeAutomationError(
+				result.stderr || result.stdout || 'Windows UI automation failed.',
+			),
+		);
+	}
+
+	return result.stdout.trim() || 'clicked extension popup';
+}
+
+export function openExtensionPopup(request, config = readConfig()) {
+	validateRequest(request);
 	const extensionNames = uniqueNames([
 		request.extensionName,
 		...(request.extensionAliases || []),
 	]);
+
+	if (process.platform === 'win32') {
+		return runWindowsAutomation({
+			browserProcessNames: browserProcessNamesFromConfig(config),
+			extensionNames,
+		});
+	}
+
+	if (process.platform !== 'darwin') {
+		throw new Error('The native popup helper supports macOS and Windows only.');
+	}
+
+	const browserApp = config.browserApp || 'Brave Browser';
 
 	try {
 		return runNativeClicker({browserApp, extensionNames});

--- a/native-helper/native-host.mjs
+++ b/native-helper/native-host.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+import {spawnSync} from 'node:child_process';
+import {Buffer} from 'node:buffer';
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import {fileURLToPath} from 'node:url';
+
+const helperDirectory = path.dirname(fileURLToPath(import.meta.url));
+const configPath = path.join(helperDirectory, 'native-host-config.json');
+const requestType = 'open-extension-popup';
+
+export function validateRequest(request) {
+	if (request?.type !== requestType) {
+		throw new Error('Unsupported native helper request type.');
+	}
+
+	if (!/^[a-p]{32}$/v.test(request.extensionId || '')) {
+		throw new Error('Invalid extension id.');
+	}
+
+	if (
+		typeof request.extensionName !== 'string' ||
+		request.extensionName.trim() === ''
+	) {
+		throw new Error('Invalid extension name.');
+	}
+}
+
+export function readNativeMessage(input = fs.readFileSync(0)) {
+	if (input.length < 4) {
+		throw new Error('Truncated native message header.');
+	}
+
+	const length = input.readUInt32LE(0);
+	const end = 4 + length;
+	if (input.length < end) {
+		throw new Error('Truncated native message body.');
+	}
+
+	return JSON.parse(input.subarray(4, end).toString('utf8'));
+}
+
+export function frameNativeMessage(message) {
+	const body = Buffer.from(JSON.stringify(message));
+	const header = Buffer.alloc(4);
+	header.writeUInt32LE(body.length, 0);
+	return Buffer.concat([header, body]);
+}
+
+function readConfig() {
+	return JSON.parse(fs.readFileSync(configPath, 'utf8'));
+}
+
+function appleScriptString(value) {
+	return JSON.stringify(value);
+}
+
+function sanitizeAutomationError(error) {
+	return String(error)
+		.replaceAll(configPath, '<config>')
+		.replaceAll(helperDirectory, '<helper>')
+		.trim();
+}
+
+function runAppleScript({browserApp, extensionName}) {
+	const script = `
+set targetName to ${appleScriptString(extensionName)}
+
+on clickByDescription(rootElement, depth, wantedText)
+	if depth > 9 then return false
+	set wantedString to wantedText as text
+	tell application "System Events"
+		try
+			set descriptionText to description of rootElement as text
+		on error
+			set descriptionText to ""
+		end try
+		ignoring case
+			if descriptionText contains wantedString then
+				try
+					click rootElement
+					return true
+				on error
+					try
+						set itemPosition to position of rootElement
+						set itemSize to size of rootElement
+						click at {((item 1 of itemPosition) + ((item 1 of itemSize) / 2)), ((item 2 of itemPosition) + ((item 2 of itemSize) / 2))}
+						return true
+					end try
+				end try
+			end if
+		end ignoring
+		try
+			repeat with child in UI elements of rootElement
+				if my clickByDescription(child, depth + 1, wantedString) then return true
+			end repeat
+		end try
+	end tell
+	return false
+end clickByDescription
+
+tell application ${appleScriptString(browserApp)} to activate
+delay 0.2
+tell application "System Events"
+	tell process ${appleScriptString(browserApp)}
+		set frontmost to true
+		if my clickByDescription(front window, 0, targetName) then
+			return "clicked pinned toolbar item"
+		end if
+		if my clickByDescription(front window, 0, "Extensions") then
+			delay 0.4
+			if my clickByDescription(front window, 0, targetName) then
+				return "clicked extensions menu item"
+			end if
+		end if
+	end tell
+end tell
+
+error "Could not find the extension in the browser toolbar or Extensions menu."
+`;
+	const result = spawnSync('/usr/bin/osascript', ['-e', script], {
+		encoding: 'utf8',
+		timeout: 8000,
+	});
+
+	if (result.status !== 0) {
+		throw new Error(
+			sanitizeAutomationError(
+				result.stderr || result.stdout || 'AppleScript failed.',
+			),
+		);
+	}
+
+	return result.stdout.trim() || 'clicked extension popup';
+}
+
+export function openExtensionPopup(request, config = readConfig()) {
+	validateRequest(request);
+	if (process.platform !== 'darwin') {
+		throw new Error('The native popup helper currently supports macOS only.');
+	}
+
+	return runAppleScript({
+		browserApp: config.browserApp || 'Brave Browser',
+		extensionName: request.extensionName.trim(),
+	});
+}
+
+function main() {
+	try {
+		const request = readNativeMessage();
+		const detail = openExtensionPopup(request);
+		process.stdout.write(frameNativeMessage({ok: true, detail}));
+	} catch (error) {
+		process.stdout.write(
+			frameNativeMessage({
+				ok: false,
+				error: error.message || 'Native helper failed.',
+			}),
+		);
+	}
+}
+
+if (
+	process.argv[1] &&
+	path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+	main();
+}

--- a/native-helper/native-host.mjs
+++ b/native-helper/native-host.mjs
@@ -25,6 +25,14 @@ export function validateRequest(request) {
 	) {
 		throw new Error('Invalid extension name.');
 	}
+
+	if (
+		request.extensionAliases !== undefined &&
+		(!Array.isArray(request.extensionAliases) ||
+			request.extensionAliases.some(alias => typeof alias !== 'string'))
+	) {
+		throw new Error('Invalid extension aliases.');
+	}
 }
 
 export function readNativeMessage(input = fs.readFileSync(0)) {
@@ -56,6 +64,10 @@ function appleScriptString(value) {
 	return JSON.stringify(value);
 }
 
+function appleScriptList(values) {
+	return `{${values.map(value => appleScriptString(value)).join(', ')}}`;
+}
+
 function sanitizeAutomationError(error) {
 	return String(error)
 		.replaceAll(configPath, '<config>')
@@ -63,9 +75,24 @@ function sanitizeAutomationError(error) {
 		.trim();
 }
 
-function runAppleScript({browserApp, extensionName}) {
+function uniqueNames(names) {
+	const seen = new Set();
+	return names
+		.map(name => name.trim())
+		.filter(name => {
+			const key = name.toLowerCase();
+			if (!name || seen.has(key)) {
+				return false;
+			}
+
+			seen.add(key);
+			return true;
+		});
+}
+
+function runAppleScript({browserApp, extensionNames}) {
 	const script = `
-set targetName to ${appleScriptString(extensionName)}
+set targetNames to ${appleScriptList(extensionNames)}
 
 on pressElement(rootElement)
 	tell application "System Events"
@@ -118,6 +145,41 @@ on clickToolbarItemByDescription(rootElement, depth, wantedText, insideToolbar)
 	return false
 end clickToolbarItemByDescription
 
+on elementText(rootElement)
+	tell application "System Events"
+		set parts to {}
+		try
+			set end of parts to description of rootElement as text
+		end try
+		try
+			set end of parts to name of rootElement as text
+		end try
+		try
+			set end of parts to value of rootElement as text
+		end try
+		return parts as text
+	end tell
+end elementText
+
+on clickMenuItemByText(rootElement, depth, wantedText)
+	if depth > 12 then return false
+	set wantedString to wantedText as text
+	tell application "System Events"
+		set combinedText to my elementText(rootElement)
+		ignoring case
+			if combinedText contains wantedString then
+				if my pressElement(rootElement) then return true
+			end if
+		end ignoring
+		try
+			repeat with child in UI elements of rootElement
+				if my clickMenuItemByText(child, depth + 1, wantedString) then return true
+			end repeat
+		end try
+	end tell
+	return false
+end clickMenuItemByText
+
 on clickToolbarItemInAnyWindow(wantedText)
 	tell application "System Events"
 		tell process ${appleScriptString(browserApp)}
@@ -129,17 +191,48 @@ on clickToolbarItemInAnyWindow(wantedText)
 	return false
 end clickToolbarItemInAnyWindow
 
+on clickMenuItemInAnyWindow(wantedText)
+	tell application "System Events"
+		tell process ${appleScriptString(browserApp)}
+			repeat with browserWindow in windows
+				set subroleText to ""
+				try
+					set subroleText to subrole of browserWindow as text
+				end try
+				if subroleText is not "AXStandardWindow" then
+					if my clickMenuItemByText(browserWindow, 0, wantedText) then return true
+				end if
+			end repeat
+		end tell
+	end tell
+	return false
+end clickMenuItemInAnyWindow
+
+on clickAnyToolbarAlias(namesToTry)
+	repeat with candidateName in namesToTry
+		if my clickToolbarItemInAnyWindow(candidateName as text) then return true
+	end repeat
+	return false
+end clickAnyToolbarAlias
+
+on clickAnyMenuAlias(namesToTry)
+	repeat with candidateName in namesToTry
+		if my clickMenuItemInAnyWindow(candidateName as text) then return true
+	end repeat
+	return false
+end clickAnyMenuAlias
+
 tell application ${appleScriptString(browserApp)} to activate
 delay 0.2
 tell application "System Events"
 	tell process ${appleScriptString(browserApp)}
 		set frontmost to true
-		if my clickToolbarItemInAnyWindow(targetName) then
+		if my clickAnyToolbarAlias(targetNames) then
 			return "clicked pinned toolbar item"
 		end if
 		if my clickToolbarItemInAnyWindow("Extensions") then
 			delay 0.4
-			if my clickToolbarItemInAnyWindow(targetName) then
+			if my clickAnyMenuAlias(targetNames) then
 				return "clicked extensions menu item"
 			end if
 		end if
@@ -172,7 +265,10 @@ export function openExtensionPopup(request, config = readConfig()) {
 
 	return runAppleScript({
 		browserApp: config.browserApp || 'Brave Browser',
-		extensionName: request.extensionName.trim(),
+		extensionNames: uniqueNames([
+			request.extensionName,
+			...(request.extensionAliases || []),
+		]),
 	});
 }
 

--- a/native-helper/native-host.mjs
+++ b/native-helper/native-host.mjs
@@ -144,6 +144,28 @@ function uniqueNames(names) {
 		});
 }
 
+function runNativeClicker({browserApp, extensionNames}) {
+	const clickerPath = path.join(helperDirectory, 'native-clicker');
+	if (!fs.existsSync(clickerPath)) {
+		throw new Error('Native clicker is not installed.');
+	}
+
+	const result = spawnSync(clickerPath, [browserApp, JSON.stringify(extensionNames)], {
+		encoding: 'utf8',
+		timeout: 8000,
+	});
+
+	if (result.status !== 0) {
+		throw new Error(
+			sanitizeAutomationError(
+				result.stderr || result.stdout || 'Native clicker failed.',
+			),
+		);
+	}
+
+	return result.stdout.trim() || 'clicked extension popup';
+}
+
 function runAppleScript({browserApp, extensionNames}) {
 	const script = `
 set targetNames to ${appleScriptList(extensionNames)}
@@ -318,12 +340,22 @@ export function openExtensionPopup(request, config = readConfig()) {
 	}
 
 	const browserApp = config.browserApp || 'Brave Browser';
+	const extensionNames = uniqueNames([
+		request.extensionName,
+		...(request.extensionAliases || []),
+	]);
+
+	try {
+		return runNativeClicker({browserApp, extensionNames});
+	} catch (error) {
+		if (!/Native clicker is not installed/v.test(error.message)) {
+			throw error;
+		}
+	}
+
 	return runAppleScript({
 		browserApp,
-		extensionNames: uniqueNames([
-			request.extensionName,
-			...(request.extensionAliases || []),
-		]),
+		extensionNames,
 	});
 }
 

--- a/native-helper/native-host.mjs
+++ b/native-helper/native-host.mjs
@@ -129,171 +129,6 @@ function sanitizeAutomationError(error) {
 		.trim();
 }
 
-function defaultBrowserProfilePath(browserApp) {
-	if (!process.env.HOME) {
-		return undefined;
-	}
-
-	if (browserApp === 'Google Chrome') {
-		return path.join(
-			process.env.HOME,
-			'Library/Application Support/Google/Chrome/Default',
-		);
-	}
-
-	if (browserApp === 'Chromium') {
-		return path.join(
-			process.env.HOME,
-			'Library/Application Support/Chromium/Default',
-		);
-	}
-
-	return path.join(
-		process.env.HOME,
-		'Library/Application Support/BraveSoftware/Brave-Browser/Default',
-	);
-}
-
-function extensionPreferencePaths(config) {
-	const profilePath =
-		config.browserProfilePath || defaultBrowserProfilePath(config.browserApp);
-	if (!profilePath) {
-		return [];
-	}
-
-	return [
-		path.join(profilePath, 'Secure Preferences'),
-		path.join(profilePath, 'Preferences'),
-	];
-}
-
-function readStoredExtensionManifest(extensionId, config) {
-	for (const preferencesPath of extensionPreferencePaths(config)) {
-		try {
-			const preferences = JSON.parse(
-				fs.readFileSync(preferencesPath, 'utf8'),
-			);
-			const manifest =
-				preferences.extensions?.settings?.[extensionId]?.manifest;
-			if (manifest && typeof manifest === 'object') {
-				return manifest;
-			}
-		} catch (error) {
-			if (error.code !== 'ENOENT') {
-				continue;
-			}
-		}
-	}
-
-	return undefined;
-}
-
-function isAsciiLetter(codePoint) {
-	return (
-		(codePoint >= 65 && codePoint <= 90) ||
-		(codePoint >= 97 && codePoint <= 122)
-	);
-}
-
-function isUrlSchemeCharacter(codePoint) {
-	return (
-		isAsciiLetter(codePoint) ||
-		(codePoint >= 48 && codePoint <= 57) ||
-		codePoint === 43 ||
-		codePoint === 45 ||
-		codePoint === 46
-	);
-}
-
-function hasControlCharacter(value) {
-	for (const character of value) {
-		const codePoint = character.codePointAt(0);
-		if (codePoint <= 0x1F || codePoint === 0x7F) {
-			return true;
-		}
-	}
-
-	return false;
-}
-
-function hasUrlScheme(value) {
-	const colonIndex = value.indexOf(':');
-	if (colonIndex < 1 || !isAsciiLetter(value.codePointAt(0))) {
-		return false;
-	}
-
-	for (let index = 1; index < colonIndex; index += 1) {
-		if (!isUrlSchemeCharacter(value.codePointAt(index))) {
-			return false;
-		}
-	}
-
-	return true;
-}
-
-function normalizeExtensionPageUrl(extensionId, pagePath) {
-	if (typeof pagePath !== 'string') {
-		return undefined;
-	}
-
-	const trimmedPath = pagePath.trim();
-	if (!trimmedPath || hasControlCharacter(trimmedPath)) {
-		return undefined;
-	}
-
-	const extensionOrigin = `chrome-extension://${extensionId}/`;
-	if (trimmedPath.startsWith(extensionOrigin)) {
-		return trimmedPath;
-	}
-
-	if (hasUrlScheme(trimmedPath)) {
-		return undefined;
-	}
-
-	return `${extensionOrigin}${trimmedPath.replace(/^\/+/v, '')}`;
-}
-
-function extensionPageCandidates(manifest) {
-	const actions = [
-		manifest.action,
-		manifest.browser_action,
-		manifest.page_action,
-	];
-	const candidates = actions
-		.map(action => action?.default_popup)
-		.filter(Boolean);
-
-	if (manifest.options_ui?.page) {
-		candidates.push(manifest.options_ui.page);
-	}
-
-	if (manifest.options_page) {
-		candidates.push(manifest.options_page);
-	}
-
-	return candidates;
-}
-
-export function getExtensionLaunchUrl(request, config = readConfig()) {
-	validateRequest(request);
-	const manifest = readStoredExtensionManifest(request.extensionId, config);
-	if (!manifest) {
-		return undefined;
-	}
-
-	for (const pagePath of extensionPageCandidates(manifest)) {
-		const launchUrl = normalizeExtensionPageUrl(
-			request.extensionId,
-			pagePath,
-		);
-		if (launchUrl) {
-			return launchUrl;
-		}
-	}
-
-	return undefined;
-}
-
 function uniqueNames(names) {
 	const seen = new Set();
 	return names
@@ -476,32 +311,6 @@ error "Could not find the extension in the browser toolbar or Extensions menu."
 	return result.stdout.trim() || 'clicked extension popup';
 }
 
-function openExtensionPageWindow({browserApp, launchUrl}) {
-	const script = `
-tell application ${appleScriptString(browserApp)}
-	activate
-	set popupWindow to make new window
-	set URL of active tab of popupWindow to ${appleScriptString(launchUrl)}
-	set bounds of popupWindow to {900, 120, 1320, 780}
-	return "opened extension popup page in window"
-end tell
-`;
-	const result = spawnSync('/usr/bin/osascript', ['-e', script], {
-		encoding: 'utf8',
-		timeout: 8000,
-	});
-
-	if (result.status !== 0) {
-		throw new Error(
-			sanitizeAutomationError(
-				result.stderr || result.stdout || 'AppleScript failed.',
-			),
-		);
-	}
-
-	return result.stdout.trim() || 'opened extension popup page in window';
-}
-
 export function openExtensionPopup(request, config = readConfig()) {
 	validateRequest(request);
 	if (process.platform !== 'darwin') {
@@ -509,34 +318,13 @@ export function openExtensionPopup(request, config = readConfig()) {
 	}
 
 	const browserApp = config.browserApp || 'Brave Browser';
-	try {
-		return runAppleScript({
-			browserApp,
-			extensionNames: uniqueNames([
-				request.extensionName,
-				...(request.extensionAliases || []),
-			]),
-		});
-	} catch (clickError) {
-		const launchUrl = getExtensionLaunchUrl(request, {
-			...config,
-			browserApp,
-		});
-		if (!launchUrl) {
-			throw clickError;
-		}
-
-		try {
-			return openExtensionPageWindow({browserApp, launchUrl});
-		} catch (fallbackError) {
-			throw new Error(
-				`${clickError.message} Popup-window fallback also failed: ${
-					fallbackError.message || fallbackError
-				}`,
-				{cause: fallbackError},
-			);
-		}
-	}
+	return runAppleScript({
+		browserApp,
+		extensionNames: uniqueNames([
+			request.extensionName,
+			...(request.extensionAliases || []),
+		]),
+	});
 }
 
 function main() {

--- a/native-helper/native-host.mjs
+++ b/native-helper/native-host.mjs
@@ -129,6 +129,171 @@ function sanitizeAutomationError(error) {
 		.trim();
 }
 
+function defaultBrowserProfilePath(browserApp) {
+	if (!process.env.HOME) {
+		return undefined;
+	}
+
+	if (browserApp === 'Google Chrome') {
+		return path.join(
+			process.env.HOME,
+			'Library/Application Support/Google/Chrome/Default',
+		);
+	}
+
+	if (browserApp === 'Chromium') {
+		return path.join(
+			process.env.HOME,
+			'Library/Application Support/Chromium/Default',
+		);
+	}
+
+	return path.join(
+		process.env.HOME,
+		'Library/Application Support/BraveSoftware/Brave-Browser/Default',
+	);
+}
+
+function extensionPreferencePaths(config) {
+	const profilePath =
+		config.browserProfilePath || defaultBrowserProfilePath(config.browserApp);
+	if (!profilePath) {
+		return [];
+	}
+
+	return [
+		path.join(profilePath, 'Secure Preferences'),
+		path.join(profilePath, 'Preferences'),
+	];
+}
+
+function readStoredExtensionManifest(extensionId, config) {
+	for (const preferencesPath of extensionPreferencePaths(config)) {
+		try {
+			const preferences = JSON.parse(
+				fs.readFileSync(preferencesPath, 'utf8'),
+			);
+			const manifest =
+				preferences.extensions?.settings?.[extensionId]?.manifest;
+			if (manifest && typeof manifest === 'object') {
+				return manifest;
+			}
+		} catch (error) {
+			if (error.code !== 'ENOENT') {
+				continue;
+			}
+		}
+	}
+
+	return undefined;
+}
+
+function isAsciiLetter(codePoint) {
+	return (
+		(codePoint >= 65 && codePoint <= 90) ||
+		(codePoint >= 97 && codePoint <= 122)
+	);
+}
+
+function isUrlSchemeCharacter(codePoint) {
+	return (
+		isAsciiLetter(codePoint) ||
+		(codePoint >= 48 && codePoint <= 57) ||
+		codePoint === 43 ||
+		codePoint === 45 ||
+		codePoint === 46
+	);
+}
+
+function hasControlCharacter(value) {
+	for (const character of value) {
+		const codePoint = character.codePointAt(0);
+		if (codePoint <= 0x1F || codePoint === 0x7F) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+function hasUrlScheme(value) {
+	const colonIndex = value.indexOf(':');
+	if (colonIndex < 1 || !isAsciiLetter(value.codePointAt(0))) {
+		return false;
+	}
+
+	for (let index = 1; index < colonIndex; index += 1) {
+		if (!isUrlSchemeCharacter(value.codePointAt(index))) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+function normalizeExtensionPageUrl(extensionId, pagePath) {
+	if (typeof pagePath !== 'string') {
+		return undefined;
+	}
+
+	const trimmedPath = pagePath.trim();
+	if (!trimmedPath || hasControlCharacter(trimmedPath)) {
+		return undefined;
+	}
+
+	const extensionOrigin = `chrome-extension://${extensionId}/`;
+	if (trimmedPath.startsWith(extensionOrigin)) {
+		return trimmedPath;
+	}
+
+	if (hasUrlScheme(trimmedPath)) {
+		return undefined;
+	}
+
+	return `${extensionOrigin}${trimmedPath.replace(/^\/+/v, '')}`;
+}
+
+function extensionPageCandidates(manifest) {
+	const actions = [
+		manifest.action,
+		manifest.browser_action,
+		manifest.page_action,
+	];
+	const candidates = actions
+		.map(action => action?.default_popup)
+		.filter(Boolean);
+
+	if (manifest.options_ui?.page) {
+		candidates.push(manifest.options_ui.page);
+	}
+
+	if (manifest.options_page) {
+		candidates.push(manifest.options_page);
+	}
+
+	return candidates;
+}
+
+export function getExtensionLaunchUrl(request, config = readConfig()) {
+	validateRequest(request);
+	const manifest = readStoredExtensionManifest(request.extensionId, config);
+	if (!manifest) {
+		return undefined;
+	}
+
+	for (const pagePath of extensionPageCandidates(manifest)) {
+		const launchUrl = normalizeExtensionPageUrl(
+			request.extensionId,
+			pagePath,
+		);
+		if (launchUrl) {
+			return launchUrl;
+		}
+	}
+
+	return undefined;
+}
+
 function uniqueNames(names) {
 	const seen = new Set();
 	return names
@@ -311,19 +476,67 @@ error "Could not find the extension in the browser toolbar or Extensions menu."
 	return result.stdout.trim() || 'clicked extension popup';
 }
 
+function openExtensionPageWindow({browserApp, launchUrl}) {
+	const script = `
+tell application ${appleScriptString(browserApp)}
+	activate
+	set popupWindow to make new window
+	set URL of active tab of popupWindow to ${appleScriptString(launchUrl)}
+	set bounds of popupWindow to {900, 120, 1320, 780}
+	return "opened extension popup page in window"
+end tell
+`;
+	const result = spawnSync('/usr/bin/osascript', ['-e', script], {
+		encoding: 'utf8',
+		timeout: 8000,
+	});
+
+	if (result.status !== 0) {
+		throw new Error(
+			sanitizeAutomationError(
+				result.stderr || result.stdout || 'AppleScript failed.',
+			),
+		);
+	}
+
+	return result.stdout.trim() || 'opened extension popup page in window';
+}
+
 export function openExtensionPopup(request, config = readConfig()) {
 	validateRequest(request);
 	if (process.platform !== 'darwin') {
 		throw new Error('The native popup helper currently supports macOS only.');
 	}
 
-	return runAppleScript({
-		browserApp: config.browserApp || 'Brave Browser',
-		extensionNames: uniqueNames([
-			request.extensionName,
-			...(request.extensionAliases || []),
-		]),
-	});
+	const browserApp = config.browserApp || 'Brave Browser';
+	try {
+		return runAppleScript({
+			browserApp,
+			extensionNames: uniqueNames([
+				request.extensionName,
+				...(request.extensionAliases || []),
+			]),
+		});
+	} catch (clickError) {
+		const launchUrl = getExtensionLaunchUrl(request, {
+			...config,
+			browserApp,
+		});
+		if (!launchUrl) {
+			throw clickError;
+		}
+
+		try {
+			return openExtensionPageWindow({browserApp, launchUrl});
+		} catch (fallbackError) {
+			throw new Error(
+				`${clickError.message} Popup-window fallback also failed: ${
+					fallbackError.message || fallbackError
+				}`,
+				{cause: fallbackError},
+			);
+		}
+	}
 }
 
 function main() {

--- a/native-helper/native-host.test.mjs
+++ b/native-helper/native-host.test.mjs
@@ -1,6 +1,8 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
+	browserProcessNamesFromConfig,
+	buildWindowsAutomationScript,
 	frameNativeMessage,
 	readNativeMessage,
 	validateRequest,
@@ -51,4 +53,31 @@ test('rejects truncated native messages with a clear error', () => {
 		() => readNativeMessage(frame.subarray(0, -2)),
 		/Truncated native message body/v,
 	);
+});
+
+test('normalizes configured Windows browser process names', () => {
+	assert.deepEqual(
+		browserProcessNamesFromConfig({
+			browserProcessNames: ['brave.exe', 'BRAVE', 'chrome'],
+		}),
+		['brave', 'chrome'],
+	);
+	assert.deepEqual(
+		browserProcessNamesFromConfig({browserApp: 'Google Chrome'}),
+		['chrome'],
+	);
+	assert.deepEqual(
+		browserProcessNamesFromConfig({browserDisplayName: 'Edge'}),
+		['msedge'],
+	);
+});
+
+test('escapes Windows automation script inputs', () => {
+	const script = buildWindowsAutomationScript({
+		browserProcessNames: ['brave'],
+		extensionNames: ["Owner's Extension"],
+	});
+
+	assert.match(script, /'Owner''s Extension'/v);
+	assert.match(script, /Find-BrowserProcess/v);
 });

--- a/native-helper/native-host.test.mjs
+++ b/native-helper/native-host.test.mjs
@@ -1,0 +1,39 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+	frameNativeMessage,
+	readNativeMessage,
+	validateRequest,
+} from './native-host.mjs';
+
+test('rejects unsupported native helper request types', () => {
+	assert.throws(
+		() => validateRequest({type: 'unexpected'}),
+		/Unsupported native helper request type/v,
+	);
+});
+
+test('rejects invalid extension ids before reading config or automating UI', () => {
+	assert.throws(
+		() =>
+			validateRequest({
+				type: 'open-extension-popup',
+				extensionId: '../bad',
+				extensionName: 'Dark Reader',
+			}),
+		/Invalid extension id/v,
+	);
+});
+
+test('rejects truncated native messages with a clear error', () => {
+	const frame = frameNativeMessage({
+		type: 'open-extension-popup',
+		extensionId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+		extensionName: 'Dark Reader',
+	});
+
+	assert.throws(
+		() => readNativeMessage(frame.subarray(0, -2)),
+		/Truncated native message body/v,
+	);
+});

--- a/native-helper/native-host.test.mjs
+++ b/native-helper/native-host.test.mjs
@@ -25,6 +25,19 @@ test('rejects invalid extension ids before reading config or automating UI', () 
 	);
 });
 
+test('rejects invalid extension aliases', () => {
+	assert.throws(
+		() =>
+			validateRequest({
+				type: 'open-extension-popup',
+				extensionId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+				extensionName: 'Dark Reader',
+				extensionAliases: ['Dark Reader', 42],
+			}),
+		/Invalid extension aliases/v,
+	);
+});
+
 test('rejects truncated native messages with a clear error', () => {
 	const frame = frameNativeMessage({
 		type: 'open-extension-popup',

--- a/native-helper/native-host.test.mjs
+++ b/native-helper/native-host.test.mjs
@@ -1,10 +1,25 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import {
 	frameNativeMessage,
+	getExtensionLaunchUrl,
 	readNativeMessage,
 	validateRequest,
 } from './native-host.mjs';
+
+const validExtensionId = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+function createProfile(preferences) {
+	const profilePath = fs.mkdtempSync(path.join(os.tmpdir(), 'ocem-profile-'));
+	fs.writeFileSync(
+		path.join(profilePath, 'Secure Preferences'),
+		JSON.stringify(preferences),
+	);
+	return profilePath;
+}
 
 test('rejects unsupported native helper request types', () => {
 	assert.throws(
@@ -30,7 +45,7 @@ test('rejects invalid extension aliases', () => {
 		() =>
 			validateRequest({
 				type: 'open-extension-popup',
-				extensionId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+				extensionId: validExtensionId,
 				extensionName: 'Dark Reader',
 				extensionAliases: ['Dark Reader', 42],
 			}),
@@ -41,12 +56,96 @@ test('rejects invalid extension aliases', () => {
 test('rejects truncated native messages with a clear error', () => {
 	const frame = frameNativeMessage({
 		type: 'open-extension-popup',
-		extensionId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+		extensionId: validExtensionId,
 		extensionName: 'Dark Reader',
 	});
 
 	assert.throws(
 		() => readNativeMessage(frame.subarray(0, -2)),
 		/Truncated native message body/v,
+	);
+});
+
+test('finds an extension action popup from stored browser preferences', () => {
+	const profilePath = createProfile({
+		extensions: {
+			settings: {
+				[validExtensionId]: {
+					manifest: {
+						action: {
+							'default_popup': 'ui/popup/index.html?source=toolbar',
+						},
+					},
+				},
+			},
+		},
+	});
+
+	assert.equal(
+		getExtensionLaunchUrl(
+			{
+				type: 'open-extension-popup',
+				extensionId: validExtensionId,
+				extensionName: 'Dark Reader',
+			},
+			{browserProfilePath: profilePath},
+		),
+		`chrome-extension://${validExtensionId}/ui/popup/index.html?source=toolbar`,
+	);
+});
+
+test('falls back to an extension options page when no popup is declared', () => {
+	const profilePath = createProfile({
+		extensions: {
+			settings: {
+				[validExtensionId]: {
+					manifest: {
+						'options_ui': {
+							page: '/options.html',
+						},
+					},
+				},
+			},
+		},
+	});
+
+	assert.equal(
+		getExtensionLaunchUrl(
+			{
+				type: 'open-extension-popup',
+				extensionId: validExtensionId,
+				extensionName: 'Options Only',
+			},
+			{browserProfilePath: profilePath},
+		),
+		`chrome-extension://${validExtensionId}/options.html`,
+	);
+});
+
+test('does not launch arbitrary external urls from stored manifests', () => {
+	const profilePath = createProfile({
+		extensions: {
+			settings: {
+				[validExtensionId]: {
+					manifest: {
+						action: {
+							'default_popup': 'https://example.com/popup.html',
+						},
+					},
+				},
+			},
+		},
+	});
+
+	assert.equal(
+		getExtensionLaunchUrl(
+			{
+				type: 'open-extension-popup',
+				extensionId: validExtensionId,
+				extensionName: 'Unsafe',
+			},
+			{browserProfilePath: profilePath},
+		),
+		undefined,
 	);
 });

--- a/native-helper/native-host.test.mjs
+++ b/native-helper/native-host.test.mjs
@@ -1,25 +1,12 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import fs from 'node:fs';
-import os from 'node:os';
-import path from 'node:path';
 import {
 	frameNativeMessage,
-	getExtensionLaunchUrl,
 	readNativeMessage,
 	validateRequest,
 } from './native-host.mjs';
 
 const validExtensionId = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
-
-function createProfile(preferences) {
-	const profilePath = fs.mkdtempSync(path.join(os.tmpdir(), 'ocem-profile-'));
-	fs.writeFileSync(
-		path.join(profilePath, 'Secure Preferences'),
-		JSON.stringify(preferences),
-	);
-	return profilePath;
-}
 
 test('rejects unsupported native helper request types', () => {
 	assert.throws(
@@ -63,89 +50,5 @@ test('rejects truncated native messages with a clear error', () => {
 	assert.throws(
 		() => readNativeMessage(frame.subarray(0, -2)),
 		/Truncated native message body/v,
-	);
-});
-
-test('finds an extension action popup from stored browser preferences', () => {
-	const profilePath = createProfile({
-		extensions: {
-			settings: {
-				[validExtensionId]: {
-					manifest: {
-						action: {
-							'default_popup': 'ui/popup/index.html?source=toolbar',
-						},
-					},
-				},
-			},
-		},
-	});
-
-	assert.equal(
-		getExtensionLaunchUrl(
-			{
-				type: 'open-extension-popup',
-				extensionId: validExtensionId,
-				extensionName: 'Dark Reader',
-			},
-			{browserProfilePath: profilePath},
-		),
-		`chrome-extension://${validExtensionId}/ui/popup/index.html?source=toolbar`,
-	);
-});
-
-test('falls back to an extension options page when no popup is declared', () => {
-	const profilePath = createProfile({
-		extensions: {
-			settings: {
-				[validExtensionId]: {
-					manifest: {
-						'options_ui': {
-							page: '/options.html',
-						},
-					},
-				},
-			},
-		},
-	});
-
-	assert.equal(
-		getExtensionLaunchUrl(
-			{
-				type: 'open-extension-popup',
-				extensionId: validExtensionId,
-				extensionName: 'Options Only',
-			},
-			{browserProfilePath: profilePath},
-		),
-		`chrome-extension://${validExtensionId}/options.html`,
-	);
-});
-
-test('does not launch arbitrary external urls from stored manifests', () => {
-	const profilePath = createProfile({
-		extensions: {
-			settings: {
-				[validExtensionId]: {
-					manifest: {
-						action: {
-							'default_popup': 'https://example.com/popup.html',
-						},
-					},
-				},
-			},
-		},
-	});
-
-	assert.equal(
-		getExtensionLaunchUrl(
-			{
-				type: 'open-extension-popup',
-				extensionId: validExtensionId,
-				extensionName: 'Unsafe',
-			},
-			{browserProfilePath: profilePath},
-		),
-		undefined,
 	);
 });

--- a/native-helper/native-http-host.mjs
+++ b/native-helper/native-http-host.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+import {spawn} from 'node:child_process';
+import {Buffer} from 'node:buffer';
+import fs from 'node:fs';
+import http from 'node:http';
+import path from 'node:path';
+import process from 'node:process';
+import {fileURLToPath} from 'node:url';
+import {
+	frameNativeMessage,
+	readNativeMessage,
+	validateRequest,
+} from './native-host.mjs';
+
+const helperDirectory = path.dirname(fileURLToPath(import.meta.url));
+const configPath = path.join(helperDirectory, 'native-host-config.json');
+const nativeHostPath = path.join(helperDirectory, 'native-host.mjs');
+const port = 17_645;
+const loopbackHost = '127.0.0.1';
+
+function readConfig() {
+	return JSON.parse(fs.readFileSync(configPath, 'utf8'));
+}
+
+function allowedOrigin() {
+	return `chrome-extension://${readConfig().extensionId}`;
+}
+
+function writeJson(response, status, payload, origin) {
+	response.writeHead(status, {
+		'content-type': 'application/json',
+		'access-control-allow-origin': origin || 'null',
+		'access-control-allow-headers': 'content-type',
+		'access-control-allow-methods': 'POST, OPTIONS',
+	});
+	response.end(JSON.stringify(payload));
+}
+
+function readRequestBody(request) {
+	return new Promise((resolve, reject) => {
+		const chunks = [];
+		let size = 0;
+		request.on('data', chunk => {
+			size += chunk.length;
+			if (size > 16_384) {
+				reject(new Error('Request body too large.'));
+				request.destroy();
+				return;
+			}
+
+			chunks.push(chunk);
+		});
+		request.on('end', () => {
+			resolve(Buffer.concat(chunks).toString('utf8'));
+		});
+		request.on('error', reject);
+	});
+}
+
+function runNativeHost(payload) {
+	return new Promise((resolve, reject) => {
+		const child = spawn(process.execPath, [nativeHostPath], {
+			stdio: ['pipe', 'pipe', 'pipe'],
+		});
+		const stdout = [];
+		const stderr = [];
+		const timer = setTimeout(() => {
+			child.kill();
+			reject(new Error('Native host timed out.'));
+		}, 10_000);
+
+		child.stdout.on('data', chunk => stdout.push(chunk));
+		child.stderr.on('data', chunk => stderr.push(chunk));
+		child.on('error', error => {
+			clearTimeout(timer);
+			reject(error);
+		});
+		child.on('close', code => {
+			clearTimeout(timer);
+			if (code !== 0) {
+				reject(
+					new Error(
+						Buffer.concat(stderr).toString('utf8') ||
+							`Native host exited with code ${code}.`,
+					),
+				);
+				return;
+			}
+
+			try {
+				resolve(readNativeMessage(Buffer.concat(stdout)));
+			} catch (error) {
+				reject(error);
+			}
+		});
+		child.stdin.end(frameNativeMessage(payload));
+	});
+}
+
+async function handlePopupRequest(request, response, origin) {
+	try {
+		const payload = JSON.parse(await readRequestBody(request));
+		validateRequest(payload);
+		writeJson(response, 200, await runNativeHost(payload), origin);
+	} catch (error) {
+		writeJson(
+			response,
+			400,
+			{ok: false, error: error.message || 'Local popup helper failed.'},
+			origin,
+		);
+	}
+}
+
+const server = http.createServer(async (request, response) => {
+	const {origin} = request.headers;
+	const expectedOrigin = allowedOrigin();
+
+	if (request.method === 'GET' && request.url === '/health') {
+		writeJson(
+			response,
+			200,
+			{ok: true},
+			origin === expectedOrigin ? expectedOrigin : undefined,
+		);
+		return;
+	}
+
+	if (origin !== expectedOrigin) {
+		writeJson(response, 403, {
+			ok: false,
+			error: 'Local popup helper rejected an unexpected origin.',
+		});
+		return;
+	}
+
+	if (request.method === 'OPTIONS') {
+		writeJson(response, 204, {}, expectedOrigin);
+		return;
+	}
+
+	if (request.method !== 'POST' || request.url !== '/open-extension-popup') {
+		writeJson(
+			response,
+			404,
+			{ok: false, error: 'Unknown local popup helper route.'},
+			expectedOrigin,
+		);
+		return;
+	}
+
+	await handlePopupRequest(request, response, expectedOrigin);
+});
+
+server.listen(port, loopbackHost, () => {
+	console.log(
+		`Native popup helper listening on http://${loopbackHost}:${port}`,
+	);
+});

--- a/native-helper/uninstall-macos.sh
+++ b/native-helper/uninstall-macos.sh
@@ -19,7 +19,11 @@ for manifest in \
 	"$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts/com.ocem.popuphost.json" \
 	"$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts/com.one_click_extensions_manager.popup_helper.json" \
 	"$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts/com.oneclickextensionsmanager.popuphelper.json" \
-	"$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts/com.openai.ocemtest.json"
+	"$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts/com.openai.ocemtest.json" \
+	"$HOME/Library/Application Support/Chromium/NativeMessagingHosts/com.ocem.popuphost.json" \
+	"$HOME/Library/Application Support/Chromium/NativeMessagingHosts/com.one_click_extensions_manager.popup_helper.json" \
+	"$HOME/Library/Application Support/Chromium/NativeMessagingHosts/com.oneclickextensionsmanager.popuphelper.json" \
+	"$HOME/Library/Application Support/Chromium/NativeMessagingHosts/com.openai.ocemtest.json"
 do
 	rm -f "$manifest"
 done

--- a/native-helper/uninstall-macos.sh
+++ b/native-helper/uninstall-macos.sh
@@ -2,9 +2,24 @@
 set -euo pipefail
 
 helper_dir="$HOME/.local/share/one-click-extensions-manager/native-helper"
+label="com.ocem.popuphost.http"
+plist_path="$HOME/Library/LaunchAgents/$label.plist"
+
+if command -v launchctl >/dev/null 2>&1; then
+	gui_domain="gui/$(id -u)"
+	launchctl bootout "$gui_domain" "$plist_path" >/dev/null 2>&1 || true
+	launchctl bootout "$gui_domain/$label" >/dev/null 2>&1 || true
+fi
+
 for manifest in \
 	"$HOME/Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts/com.ocem.popuphost.json" \
-	"$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts/com.ocem.popuphost.json"
+	"$HOME/Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts/com.one_click_extensions_manager.popup_helper.json" \
+	"$HOME/Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts/com.oneclickextensionsmanager.popuphelper.json" \
+	"$HOME/Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts/com.openai.ocemtest.json" \
+	"$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts/com.ocem.popuphost.json" \
+	"$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts/com.one_click_extensions_manager.popup_helper.json" \
+	"$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts/com.oneclickextensionsmanager.popuphelper.json" \
+	"$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts/com.openai.ocemtest.json"
 do
 	rm -f "$manifest"
 done
@@ -17,5 +32,5 @@ if [[ -f "$helper_dir/http-host.pid" ]]; then
 fi
 
 rm -rf "$helper_dir"
-rm -f "$HOME/Library/LaunchAgents/com.ocem.popuphost.http.plist"
+rm -f "$plist_path"
 echo "Uninstalled native popup helper."

--- a/native-helper/uninstall-macos.sh
+++ b/native-helper/uninstall-macos.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+helper_dir="$HOME/.local/share/one-click-extensions-manager/native-helper"
+for manifest in \
+	"$HOME/Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts/com.ocem.popuphost.json" \
+	"$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts/com.ocem.popuphost.json"
+do
+	rm -f "$manifest"
+done
+
+if [[ -f "$helper_dir/http-host.pid" ]]; then
+	pid="$(cat "$helper_dir/http-host.pid" || true)"
+	if [[ "$pid" =~ ^[0-9]+$ ]] && kill -0 "$pid" 2>/dev/null; then
+		kill "$pid" || true
+	fi
+fi
+
+rm -rf "$helper_dir"
+rm -f "$HOME/Library/LaunchAgents/com.ocem.popuphost.http.plist"
+echo "Uninstalled native popup helper."

--- a/native-helper/uninstall-windows.ps1
+++ b/native-helper/uninstall-windows.ps1
@@ -1,0 +1,32 @@
+param(
+	[switch] $KeepFiles
+)
+
+$installDir = Join-Path $env:LOCALAPPDATA 'OnFire Extensions Manager\native-helper'
+$pidPath = Join-Path $installDir 'http-host.pid'
+$taskName = 'OnFire Extensions Manager Popup Helper'
+
+if (Get-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue) {
+	Stop-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
+	Unregister-ScheduledTask -TaskName $taskName -Confirm:$false
+	Write-Host "[OK] Removed scheduled task: $taskName"
+}
+
+if (Test-Path $pidPath) {
+	$pidValue = Get-Content $pidPath -ErrorAction SilentlyContinue
+	if ($pidValue -match '^[0-9]+$') {
+		Stop-Process -Id ([int] $pidValue) -ErrorAction SilentlyContinue
+	}
+}
+
+$escapedInstallDir = [Regex]::Escape($installDir)
+Get-CimInstance Win32_Process -Filter "Name = 'node.exe'" -ErrorAction SilentlyContinue |
+	Where-Object { $_.CommandLine -match 'native-http-host\.mjs' -and $_.CommandLine -match $escapedInstallDir } |
+	ForEach-Object { Stop-Process -Id $_.ProcessId -ErrorAction SilentlyContinue }
+
+if (-not $KeepFiles -and (Test-Path $installDir)) {
+	Remove-Item -Recurse -Force $installDir
+	Write-Host "[OK] Removed helper files: $installDir"
+}
+
+Write-Host '[OK] Windows popup helper uninstall complete.'

--- a/native-helper/uninstall.mjs
+++ b/native-helper/uninstall.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+import {spawnSync} from 'node:child_process';
+import path from 'node:path';
+import process from 'node:process';
+import {fileURLToPath} from 'node:url';
+
+const helperDirectory = path.dirname(fileURLToPath(import.meta.url));
+
+function powershellPath() {
+	if (process.env.SystemRoot) {
+		return path.join(
+			process.env.SystemRoot,
+			'System32',
+			'WindowsPowerShell',
+			'v1.0',
+			'powershell.exe',
+		);
+	}
+
+	return 'powershell.exe';
+}
+
+function run(command, arguments_) {
+	const result = spawnSync(command, arguments_, {stdio: 'inherit'});
+	process.exit(result.status ?? 1);
+}
+
+if (process.platform === 'darwin') {
+	run('bash', [path.join(helperDirectory, 'uninstall-macos.sh')]);
+}
+
+if (process.platform === 'win32') {
+	run(powershellPath(), [
+		'-NoProfile',
+		'-ExecutionPolicy',
+		'Bypass',
+		'-File',
+		path.join(helperDirectory, 'uninstall-windows.ps1'),
+	]);
+}
+
+console.error(
+	'The native popup helper uninstaller supports macOS and Windows only.',
+);
+process.exit(1);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "one-click-extensions-manager",
+	"name": "onfire-extensions-manager",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,23 @@
 {
+	"name": "onfire-extensions-manager",
+	"description": "OnFire fork of One Click Extension Manager with folders, popup access, extension toggles, and uninstall controls.",
 	"type": "module",
 	"private": true,
+	"homepage": "https://github.com/onfire7777/one-click-extensions-manager-V2",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/onfire7777/one-click-extensions-manager-V2.git"
+	},
+	"license": "MIT",
 	"engines": {
 		"node": ">=22"
 	},
 	"scripts": {
 		"build": "rollup --config",
 		"fix": "run-p 'lint -- --fix' format",
+		"helper:diagnose": "node native-helper/diagnose.mjs",
+		"helper:install": "node native-helper/install.mjs",
+		"helper:uninstall": "node native-helper/uninstall.mjs",
 		"lint": "eslint .",
 		"format": "prettier . --write",
 		"format:check": "prettier . --check",

--- a/privacy-policy.md
+++ b/privacy-policy.md
@@ -8,7 +8,7 @@ This Privacy Policy describes Our policies and procedures on the collection, use
 
 For the purposes of this Privacy Policy:
 
-Application means the software program provided by us downloaded by You on any electronic device, named **One click extensions manager**.
+Application means the software program provided by us downloaded by You on any electronic device, named **OnFire Extensions Manager**, a modified fork of One Click Extension Manager.
 
 Device means any device that can access the Service such as a computer, a cellphone or a digital tablet.
 
@@ -27,4 +27,4 @@ You means the individual accessing or using the Service, or the company, or othe
 Contact Us
 If you have any questions about this Privacy Policy, You can contact us:
 
-By visiting this page: https://github.com/hankxdev/one-click-extensions-manager
+By visiting this page: https://github.com/onfire7777/one-click-extensions-manager-V2

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-## <img src="source/logo.png" width="30" align="left"> One Click Extension Manager
+## <img src="source/onfire-logo.svg" width="30" align="left"> OnFire Extensions Manager
 
 <img src="screencast.gif" align="right" alt="">
 
@@ -6,20 +6,69 @@
 
 ![](https://user-images.githubusercontent.com/1402241/226161439-960aebe9-cad1-4d4d-a59a-f007db2abfa3.png)
 
-A _very simple_ Chrome extension to manage your Chrome extensions.
+OnFire Extensions Manager is a modified fork of One Click Extension Manager,
+customized for a more capable local Brave/Chromium workflow.
 
-It only requires the `management` permission.
+This fork is the version to use from this repository and locally. It is
+visually branded as **OnFire Extensions Manager** so it is easy to distinguish
+from the original Chrome Web Store extension.
+
+Current fork additions include:
+
+- Opening other extensions' popups from the manager, including unpinned
+  extensions when the native helper is installed.
+- Folder organization, search, and compact status filters.
+- Enable/disable toggles plus a remove action that uninstalls extensions from
+  the browser.
+- A compact modern popup UI for local use.
+- Cross-platform native helper setup for macOS and Windows.
+
+## Original project credit
+
+This project is based on the original
+[One Click Extension Manager](https://github.com/hankxdev/one-click-extensions-manager)
+by [Hank Yang](https://momane.com/) and
+[Federico Brigante](https://fregante.com/). The original MIT license and
+copyright notice are preserved in this repository.
 
 ## Install
 
-[link-chrome]: https://chrome.google.com/webstore/detail/one-click-extension-manag/pbgjpgbpljobkekbhnnmlikbbfhbhmem 'Version published on Chrome Web Store'
-[link-edge]: https://microsoftedge.microsoft.com/addons/detail/one-click-extensions-mana/jdodenbllldnoogfmbmmgpieafbnaogm 'Version published on Edge Web Stroe'
+This fork is intended to be loaded unpacked from this repository, not installed
+from the original Web Store listing.
 
-[<img src="https://raw.githubusercontent.com/alrra/browser-logos/90fdf03c/src/chrome/chrome.svg" width="48" alt="Chrome" valign="middle">][link-chrome] [<img valign="middle" src="https://img.shields.io/chrome-web-store/v/pbgjpgbpljobkekbhnnmlikbbfhbhmem.svg?label=%20">][link-chrome] and other Chromium browsers
+1. Run `npm install` once.
+2. Run `npm test` to lint, test, and build `distribution/`.
+3. In Brave or Chrome, open `chrome://extensions`.
+4. Enable Developer Mode.
+5. Load unpacked from this repository's `distribution/` folder.
 
-[<img src="https://raw.githubusercontent.com/alrra/browser-logos/90fdf03c/src/edge/edge.svg" width="48" alt="Edge" valign="middle">][link-edge] [<img valign="middle" src="https://img.shields.io/badge/dynamic/json?add-on&prefix=v&query=%24.version&url=https%3A%2F%2Fmicrosoftedge.microsoft.com%2Faddons%2Fgetproductdetailsbycrxid%2Fjdodenbllldnoogfmbmmgpieafbnaogm&label=%20">][link-edge]
+The installed extension should appear as **OnFire Extensions Manager** with the
+custom OnFire logo.
 
-[<img src="https://raw.githubusercontent.com/iamcal/emoji-data/08ec822c38e0b7a6fea0b92a9c42e02b6ba24a84/img-apple-160/1f99a.png" width="48" valign="middle">](https://github.com/sponsors/fregante) _If you like this extension, consider [sponsoring or hiring](https://github.com/sponsors/fregante) the maintainer [@fregante](https://twitter.com/fregante)_
+## Native popup helper
+
+The native popup helper is required for the "open another extension's popup"
+feature. It supports macOS and Windows.
+
+After loading the unpacked extension, copy this extension's ID from
+`chrome://extensions`, then run the cross-platform installer:
+
+```sh
+npm run helper:install -- <extension-id> brave
+```
+
+Use `chrome` instead of `brave` when installing for Google Chrome. On Windows,
+`edge` and `chromium` are also accepted.
+
+Diagnostics and cleanup use the same cross-platform wrappers:
+
+```sh
+npm run helper:diagnose -- brave
+npm run helper:uninstall
+```
+
+Platform-specific scripts remain available under `native-helper/` for users who
+prefer direct macOS shell or Windows PowerShell commands.
 
 ## Internationalization
 
@@ -43,7 +92,7 @@ It's available in several languages:
 
 You can suggest improvements or new languages using the `web-ext-translator` web tool:
 
-1. Visit https://lusito.github.io/web-ext-translator/?gh=https://github.com/hankxdev/one-click-extensions-manager/tree/main
+1. Visit https://lusito.github.io/web-ext-translator/?gh=https://github.com/onfire7777/one-click-extensions-manager-V2/tree/main
 2. Make changes to your language
 3. Open a PR on this repo to submit your changes
 

--- a/source/_locales/de/messages.json
+++ b/source/_locales/de/messages.json
@@ -9,7 +9,7 @@
 		"message": "Verwalte einfach deine Erweiterungen: auflisten, entfernen, ein- und ausschalten."
 	},
 	"extName": {
-		"message": "One-Click Erweiterungsmanager"
+		"message": "OnFire Extensions Manager"
 	},
 	"gotoOpt": {
 		"message": "Einstellungen…"

--- a/source/_locales/en/messages.json
+++ b/source/_locales/en/messages.json
@@ -15,7 +15,7 @@
 		"message": "View, use, enable, disable, and remove your extensions with ease."
 	},
 	"extName": {
-		"message": "One Click Extensions Manager V2"
+		"message": "OnFire Extensions Manager"
 	},
 	"extensionMenuUnavailable": {
 		"message": "Extension menu unavailable"
@@ -39,7 +39,7 @@
 		"message": "Extension action failed."
 	},
 	"nativeHelperMissing": {
-		"message": "Native popup helper is not installed. Run native-helper/install-macos.sh from this repository."
+		"message": "Native popup helper is not installed. Run npm run helper:install -- <extension-id> brave from this repository."
 	},
 	"nativeHelperOpenFailed": {
 		"message": "Native popup helper could not open this extension popup."

--- a/source/_locales/en/messages.json
+++ b/source/_locales/en/messages.json
@@ -15,7 +15,7 @@
 		"message": "View, use, enable, disable, and remove your extensions with ease."
 	},
 	"extName": {
-		"message": "One Click Extensions Manager"
+		"message": "One Click Extensions Manager V2"
 	},
 	"extensionMenuUnavailable": {
 		"message": "Extension menu unavailable"

--- a/source/_locales/en/messages.json
+++ b/source/_locales/en/messages.json
@@ -2,14 +2,23 @@
 	"disAll": {
 		"message": "Disable all"
 	},
+	"disableExtension": {
+		"message": "Disable extension"
+	},
 	"enableAll": {
 		"message": "Enable all"
 	},
+	"enableExtension": {
+		"message": "Enable extension"
+	},
 	"extDesc": {
-		"message": "View, enable, disable, remove your extensions with ease."
+		"message": "View, use, enable, disable, and remove your extensions with ease."
 	},
 	"extName": {
 		"message": "One Click Extensions Manager"
+	},
+	"extensionMenuUnavailable": {
+		"message": "Extension menu unavailable"
 	},
 	"gotoOpt": {
 		"message": "Options…"
@@ -23,6 +32,18 @@
 	"openUrl": {
 		"message": "See on the Web Store"
 	},
+	"openToolbarPopup": {
+		"message": "Open extension popup"
+	},
+	"nativeHelperFailed": {
+		"message": "Extension action failed."
+	},
+	"nativeHelperMissing": {
+		"message": "Native popup helper is not installed. Run native-helper/install-macos.sh from this repository."
+	},
+	"nativeHelperOpenFailed": {
+		"message": "Native popup helper could not open this extension popup."
+	},
 	"searchTxt": {
 		"message": "Search by name…"
 	},
@@ -34,5 +55,8 @@
 	},
 	"uninstall": {
 		"message": "Remove from Chrome"
+	},
+	"useExtension": {
+		"message": "Open extension popup"
 	}
 }

--- a/source/_locales/es/messages.json
+++ b/source/_locales/es/messages.json
@@ -9,7 +9,7 @@
 		"message": "Ver, activar, desactivar y eliminar tus extensiones con facilidad."
 	},
 	"extName": {
-		"message": "Administrador de extensión de un clic"
+		"message": "OnFire Extensions Manager"
 	},
 	"gotoOpt": {
 		"message": "Opciones…"

--- a/source/_locales/fr/messages.json
+++ b/source/_locales/fr/messages.json
@@ -12,8 +12,7 @@
 		"hash": "557ac2dd0ce9b4249f7dc37868bcfccf"
 	},
 	"extName": {
-		"message": "Gestionnaire d‘extensions à un clic",
-		"hash": "9f7e3f659272f7b34a4073ddd8e29658"
+		"message": "OnFire Extensions Manager"
 	},
 	"gotoOpt": {
 		"message": "Options…",

--- a/source/_locales/he/messages.json
+++ b/source/_locales/he/messages.json
@@ -9,7 +9,7 @@
 		"message": "צפו, הפעילו / השביתו או הסירו תוספים בקלות"
 	},
 	"extName": {
-		"message": "One Click Extensions Manager"
+		"message": "OnFire Extensions Manager"
 	},
 	"gotoOpt": {
 		"message": "אפשרויות נוספות"

--- a/source/_locales/it/messages.json
+++ b/source/_locales/it/messages.json
@@ -12,8 +12,7 @@
 		"hash": "557ac2dd0ce9b4249f7dc37868bcfccf"
 	},
 	"extName": {
-		"message": "One Click Extensions Manager",
-		"hash": "9f7e3f659272f7b34a4073ddd8e29658"
+		"message": "OnFire Extensions Manager"
 	},
 	"gotoOpt": {
 		"message": "Opzioni…",

--- a/source/_locales/ja/messages.json
+++ b/source/_locales/ja/messages.json
@@ -9,7 +9,7 @@
 		"message": "1回のクリックで広告表示オプションを管理する。"
 	},
 	"extName": {
-		"message": "ワンクリックエクステンションマネージャー"
+		"message": "OnFire Extensions Manager"
 	},
 	"gotoOpt": {
 		"message": "オプションページに移動"

--- a/source/_locales/ko/messages.json
+++ b/source/_locales/ko/messages.json
@@ -9,7 +9,7 @@
 		"message": "한 번의 클릭으로 광고 확장 관리."
 	},
 	"extName": {
-		"message": "원 클릭 확장 관리자"
+		"message": "OnFire Extensions Manager"
 	},
 	"gotoOpt": {
 		"message": "옵션 페이지로 이동"

--- a/source/_locales/lv/messages.json
+++ b/source/_locales/lv/messages.json
@@ -12,8 +12,7 @@
 		"hash": "557ac2dd0ce9b4249f7dc37868bcfccf"
 	},
 	"extName": {
-		"message": "Viena klikšķa paplašinājumu pārvaldnieks",
-		"hash": "9f7e3f659272f7b34a4073ddd8e29658"
+		"message": "OnFire Extensions Manager"
 	},
 	"gotoOpt": {
 		"message": "Iestatījumi…",
@@ -46,6 +45,7 @@
 		"message": "Noņemt šo paplašinājumu",
 		"hash": "a04a561e0b5c8b0210a17382781cabd1"
 	},
-
-	"__WET_LOCALE__": {"message": "lv"}
+	"__WET_LOCALE__": {
+		"message": "lv"
+	}
 }

--- a/source/_locales/nl/messages.json
+++ b/source/_locales/nl/messages.json
@@ -12,8 +12,7 @@
 		"hash": "557ac2dd0ce9b4249f7dc37868bcfccf"
 	},
 	"extName": {
-		"message": "One Click Extensions Manager",
-		"hash": "9f7e3f659272f7b34a4073ddd8e29658"
+		"message": "OnFire Extensions Manager"
 	},
 	"gotoOpt": {
 		"message": "Opties…",
@@ -46,6 +45,7 @@
 		"message": "Verwijderen uit Chrome",
 		"hash": "a04a561e0b5c8b0210a17382781cabd1"
 	},
-
-	"__WET_LOCALE__": {"message": "nl"}
+	"__WET_LOCALE__": {
+		"message": "nl"
+	}
 }

--- a/source/_locales/pl/messages.json
+++ b/source/_locales/pl/messages.json
@@ -12,8 +12,7 @@
 		"hash": "557ac2dd0ce9b4249f7dc37868bcfccf"
 	},
 	"extName": {
-		"message": "One Click Extensions Manager",
-		"hash": "9f7e3f659272f7b34a4073ddd8e29658"
+		"message": "OnFire Extensions Manager"
 	},
 	"gotoOpt": {
 		"message": "Opcje...",
@@ -46,6 +45,7 @@
 		"message": "Usuń z Chrome",
 		"hash": "a04a561e0b5c8b0210a17382781cabd1"
 	},
-
-	"__WET_LOCALE__": {"message": "pl"}
+	"__WET_LOCALE__": {
+		"message": "pl"
+	}
 }

--- a/source/_locales/ru/messages.json
+++ b/source/_locales/ru/messages.json
@@ -9,7 +9,7 @@
 		"message": "Управление расширение одним щелчком мыши."
 	},
 	"extName": {
-		"message": "One Click менеджер расширений"
+		"message": "OnFire Extensions Manager"
 	},
 	"gotoOpt": {
 		"message": "Перейти на страницу настроек"

--- a/source/_locales/tr/messages.json
+++ b/source/_locales/tr/messages.json
@@ -12,8 +12,7 @@
 		"hash": "557ac2dd0ce9b4249f7dc37868bcfccf"
 	},
 	"extName": {
-		"message": "Bir-Tık Uzantı Yöneticisi",
-		"hash": "9f7e3f659272f7b34a4073ddd8e29658"
+		"message": "OnFire Extensions Manager"
 	},
 	"gotoOpt": {
 		"message": "Ayarlar sayfasına git",

--- a/source/_locales/zh_CN/messages.json
+++ b/source/_locales/zh_CN/messages.json
@@ -9,7 +9,7 @@
 		"message": "一键管理所有扩展，快速激活、禁用、卸载插件。"
 	},
 	"extName": {
-		"message": "快捷扩展管理"
+		"message": "OnFire Extensions Manager"
 	},
 	"gotoOpt": {
 		"message": "打开设置页面"

--- a/source/_locales/zh_TW/messages.json
+++ b/source/_locales/zh_TW/messages.json
@@ -12,8 +12,7 @@
 		"hash": "557ac2dd0ce9b4249f7dc37868bcfccf"
 	},
 	"extName": {
-		"message": "快捷擴展管理",
-		"hash": "9f7e3f659272f7b34a4073ddd8e29658"
+		"message": "OnFire Extensions Manager"
 	},
 	"gotoOpt": {
 		"message": "打開設置頁面",

--- a/source/app.svelte
+++ b/source/app.svelte
@@ -370,12 +370,23 @@
 <svelte:window onkeydown={keyboardNavigationHandler} />
 <main class="app-shell">
 	<header class="topbar">
-		<div>
-			<h1>Extensions</h1>
-			<p>
-				{extensionStats.total} total, {extensionStats.active} active, {folders.length}
-				folders
-			</p>
+		<div class="brand-block">
+			<img
+				class="brand-logo"
+				src="onfire-logo.svg"
+				alt=""
+				width="34"
+				height="34"
+				aria-hidden="true"
+			/>
+			<div>
+				<p class="brand-label">OnFire Extensions Manager</p>
+				<h1>Extensions</h1>
+				<p>
+					{extensionStats.total} total, {extensionStats.active} active,
+					{folders.length} folders
+				</p>
+			</div>
 		</div>
 		<button
 			type="button"

--- a/source/app.svelte
+++ b/source/app.svelte
@@ -5,43 +5,180 @@
 	import {focusNext, focusPrevious} from './lib/focus-next.js';
 	import prepareExtensionList from './lib/prepare-extension-list.js';
 	import UndoStack from './lib/undo-stack.js';
-	import optionsStorage, {togglePin} from './options-storage.js';
+	import optionsStorage, {
+		assignExtensionFolder,
+		createExtensionFolder,
+		deleteExtensionFolder,
+		removeExtensionPreferences,
+		togglePin,
+	} from './options-storage.js';
 
+	const allFolderId = 'all';
+	const noFolderId = 'unfiled';
 	const getI18N = chrome.i18n.getMessage;
 	const undoStack = new UndoStack(globalThis);
+	const statusFilters = [
+		{label: 'All', mode: 'all'},
+		{label: 'On', mode: 'enabled'},
+		{label: 'Off', mode: 'disabled'},
+	];
 
+	let activeFolderId = $state(allFolderId);
+	let deleteFolderArmed = $state(false);
 	let extensions = $state([]);
+	let filterMode = $state('all');
+	let folders = $state([]);
+	let newFolderName = $state('');
+	let organizeMode = $state(false);
 	let searchValue = $state('');
 	let showExtras = $state(false);
 	let showStickyInfoMessage = $state(
 		!localStorage.getItem('sticky-info-message'),
 	);
 	let showInfoMessage = $state(!localStorage.getItem('undo-info-message'));
+
+	const extensionStats = $derived.by(() => {
+		const total = extensions.length;
+		const active = extensions.filter(({enabled}) => enabled).length;
+
+		return {
+			active,
+			disabled: total - active,
+			total,
+		};
+	});
+
 	const visibleExtensions = $derived.by(() => {
 		const keywords = searchValue
 			.toLowerCase()
 			.split(' ')
 			.filter(s => s.length);
 
-		return extensions.filter(extension =>
-			keywords.every(word => extension.indexedName.includes(word)),
-		);
+		return extensions
+			.filter(extension =>
+				keywords.every(word => extension.indexedName.includes(word)),
+			)
+			.filter(extension => {
+				if (filterMode === 'enabled') {
+					return extension.enabled;
+				}
+
+				if (filterMode === 'disabled') {
+					return !extension.enabled;
+				}
+
+				return true;
+			})
+			.filter(extension => {
+				if (activeFolderId === noFolderId) {
+					return !extension.folderId;
+				}
+
+				if (activeFolderId !== allFolderId) {
+					return extension.folderId === activeFolderId;
+				}
+
+				return true;
+			});
 	});
 
-	// "Disable/enable all" shows the button again, unless the user clicked already "hide" in the current session
+	const folderSections = $derived.by(() => {
+		if (activeFolderId !== allFolderId) {
+			return [
+				{
+					id: activeFolderId,
+					name: getFolderLabel(activeFolderId),
+					extensions: visibleExtensions,
+				},
+			];
+		}
+
+		const sections = folders
+			.map(folder => ({
+				...folder,
+				extensions: visibleExtensions.filter(
+					extension => extension.folderId === folder.id,
+				),
+			}))
+			.filter(
+				({extensions: sectionExtensions}) => sectionExtensions.length > 0,
+			);
+		const unfiled = visibleExtensions.filter(
+			({folderId: extensionFolderId}) => !extensionFolderId,
+		);
+
+		if (unfiled.length > 0) {
+			sections.push({
+				id: noFolderId,
+				name: 'No folder',
+				extensions: unfiled,
+			});
+		}
+
+		return sections.length > 0
+			? sections
+			: [
+					{
+						id: allFolderId,
+						name: 'All extensions',
+						extensions: visibleExtensions,
+					},
+				];
+	});
+
 	let userClickedHideInfoMessage = $state(false);
 
-	const options = optionsStorage.getAll();
-
-	options.then(({showButtons, width, position}) => {
+	optionsStorage.getAll().then(({showButtons, width, position}) => {
 		if (showButtons === 'always') {
 			showExtras = true;
 		}
 
 		if (position === 'popup' || position === 'window') {
-			document.documentElement.style.width = `${width || 400}px`;
+			document.documentElement.style.width = `${width || 500}px`;
 		}
 	});
+
+	function message(key, fallback) {
+		return getI18N(key) || fallback;
+	}
+
+	function getFolderLabel(selectedFolderId) {
+		if (selectedFolderId === noFolderId) {
+			return 'No folder';
+		}
+
+		if (selectedFolderId === allFolderId) {
+			return 'All extensions';
+		}
+
+		return folders.find(({id}) => id === selectedFolderId)?.name ?? 'Folder';
+	}
+
+	function getFolderCount(selectedFolderId) {
+		if (selectedFolderId === allFolderId) {
+			return extensions.length;
+		}
+
+		if (selectedFolderId === noFolderId) {
+			return extensions.filter(extension => !extension.folderId).length;
+		}
+
+		return extensions.filter(
+			extension => extension.folderId === selectedFolderId,
+		).length;
+	}
+
+	function getFilterCount(mode) {
+		if (mode === 'enabled') {
+			return extensionStats.active;
+		}
+
+		if (mode === 'disabled') {
+			return extensionStats.disabled;
+		}
+
+		return extensionStats.total;
+	}
 
 	function hideInfoMessage() {
 		localStorage.setItem('undo-info-message', Date.now());
@@ -62,13 +199,13 @@
 			}
 
 			case 'ArrowDown': {
-				focusNext('.ext-name, [type="search"]');
+				focusNext('.ext-main, [type="search"]');
 				event.preventDefault();
 				break;
 			}
 
 			case 'ArrowUp': {
-				focusPrevious('.ext-name, [type="search"]');
+				focusPrevious('.ext-main, [type="search"]');
 				event.preventDefault();
 				break;
 			}
@@ -106,8 +243,16 @@
 		});
 	}
 
-	function handleUninstalled(deleted) {
-		extensions = extensions.filter(({id}) => id !== deleted);
+	function handleBulkAction(enable) {
+		toggleAll(enable);
+		showInfoMessage = true;
+	}
+
+	function handleUninstalled(deletedExtensionId) {
+		extensions = extensions.filter(({id}) => id !== deletedExtensionId);
+		removeExtensionPreferences(deletedExtensionId).catch(error => {
+			console.warn('Failed to clean up extension preferences:', error);
+		});
 	}
 
 	async function handleInstalled(installed) {
@@ -135,26 +280,75 @@
 	}
 
 	async function prepare() {
+		const options = await optionsStorage.getAll();
+		folders = options.extensionFolders;
 		extensions = await prepareExtensionList(await chrome.management.getAll());
+
+		if (
+			activeFolderId !== allFolderId &&
+			activeFolderId !== noFolderId &&
+			!folders.some(({id}) => id === activeFolderId)
+		) {
+			activeFolderId = allFolderId;
+		}
 	}
 
 	async function handlePin(extensionId) {
 		const wasPinned = await togglePin(extensionId);
-		await prepare(); // Refresh the list to show new order
+		await prepare();
 		return wasPinned;
+	}
+
+	async function handleFolderChange(extensionId, folderId) {
+		await assignExtensionFolder(extensionId, folderId);
+		await prepare();
+	}
+
+	function selectFolder(folderId) {
+		activeFolderId = folderId;
+		deleteFolderArmed = false;
+	}
+
+	async function handleCreateFolder() {
+		const name = newFolderName.trim();
+		if (!name) {
+			return;
+		}
+
+		const folder = await createExtensionFolder(name);
+		newFolderName = '';
+		activeFolderId = folder.id;
+		deleteFolderArmed = false;
+		organizeMode = true;
+		await prepare();
+	}
+
+	async function handleDeleteFolder() {
+		if (!deleteFolderArmed) {
+			deleteFolderArmed = true;
+			return;
+		}
+
+		await deleteExtensionFolder(activeFolderId);
+		activeFolderId = allFolderId;
+		deleteFolderArmed = false;
+		await prepare();
+	}
+
+	function clearSearch() {
+		searchValue = '';
+		document.querySelector('[type="search"]')?.focus();
 	}
 
 	onMount(async () => {
 		await prepare();
 
-		// Add listeners
 		chrome.management.onUninstalled.addListener(handleUninstalled);
 		chrome.management.onInstalled.addListener(handleInstalled);
 		chrome.management.onEnabled.addListener(handleEnabled);
 		chrome.management.onDisabled.addListener(handleDisabled);
 		window.addEventListener('blur', prepare);
 
-		// Cleanup function
 		return () => {
 			chrome.management.onUninstalled.removeListener(handleUninstalled);
 			chrome.management.onInstalled.removeListener(handleInstalled);
@@ -164,43 +358,44 @@
 		};
 	});
 
-	// Toggle extra buttons on right click on the name
-	// After the first click, allow the native context menu
 	function onContextMenu(event) {
 		if (!showExtras) {
 			showExtras = true;
 			event.preventDefault();
 		}
 	}
-
-	function handleBurger(event) {
-		const select = event.currentTarget;
-		switch (select.value) {
-			case 'enable': {
-				toggleAll(true);
-				showInfoMessage = true;
-				break;
-			}
-
-			case 'disable': {
-				toggleAll(false);
-				showInfoMessage = true;
-				break;
-			}
-
-			default:
-		}
-
-		select.value = ''; // Reset the select. PreventDefault doesn't work
-	}
 </script>
 
 <svelte:window onkeydown={keyboardNavigationHandler} />
-<main>
+<main class="app-shell">
+	<header class="topbar">
+		<div>
+			<h1>Extensions</h1>
+			<p>
+				{extensionStats.total} total, {extensionStats.active} active, {folders.length}
+				folders
+			</p>
+		</div>
+		<button
+			type="button"
+			class="organize-toggle"
+			class:active={organizeMode}
+			aria-pressed={organizeMode}
+			onclick={() => {
+				organizeMode = !organizeMode;
+				deleteFolderArmed = false;
+			}}
+		>
+			{organizeMode ? 'Done' : 'Organize'}
+		</button>
+	</header>
+
 	{#if showInfoMessage && !userClickedHideInfoMessage}
 		<p class="notice">
-			<!-- eslint-disable-next-line svelte/no-at-html-tags -- Static -->
-			{@html replaceModifierIfMac(getI18N('undoInfoMsg'), 'z')}
+			<span>
+				<!-- eslint-disable-next-line svelte/no-at-html-tags -- Static -->
+				{@html replaceModifierIfMac(getI18N('undoInfoMsg'), 'z')}
+			</span>
 			<a class="hide-action" href="#hide" onclick={hideInfoMessage}
 				>{getI18N('hideInfoMsg')}</a
 			>
@@ -208,37 +403,149 @@
 	{/if}
 	{#if showStickyInfoMessage}
 		<p class="notice">
-			<!-- eslint-disable-next-line svelte/no-at-html-tags -- Static -->
-			{@html replaceModifierIfMac(getI18N('stickyInfoMsg'), '')}
+			<span>
+				<!-- eslint-disable-next-line svelte/no-at-html-tags -- Static -->
+				{@html replaceModifierIfMac(getI18N('stickyInfoMsg'), '')}
+			</span>
 			<a class="hide-action" href="#hide" onclick={hideStickyInfoMessage}
 				>{getI18N('hideInfoMsg')}</a
 			>
 		</p>
 	{/if}
-	<div class="header">
-		<!-- svelte-ignore a11y_autofocus -->
-		<input
-			autofocus
-			placeholder={getI18N('searchTxt')}
-			bind:value={searchValue}
-			type="search"
-		/>
-		<select class="header-burger" onchange={handleBurger}>
-			<option value=""></option>
-			<option value="disable">{getI18N('disAll')}</option>
-			<option value="enable">{getI18N('enableAll')}</option>
-		</select>
-	</div>
-	<ul id="ext-list">
-		{#each visibleExtensions as extension (extension.id)}
-			<Extension
-				{...extension}
-				bind:enabled={extension.enabled}
-				bind:showExtras
-				oncontextmenu={onContextMenu}
-				onpin={() => handlePin(extension.id)}
-				{undoStack}
-			/>
-		{/each}
-	</ul>
+
+	<section class="control-panel" aria-label="Extension controls">
+		<div class="search-row">
+			<label class="search-box">
+				<span class="search-label">Search</span>
+				<!-- svelte-ignore a11y_autofocus -->
+				<input
+					autofocus
+					placeholder={message('searchTxt', 'Search by name...')}
+					bind:value={searchValue}
+					type="search"
+				/>
+			</label>
+			{#if searchValue}
+				<button type="button" class="clear-search" onclick={clearSearch}>
+					Clear
+				</button>
+			{/if}
+		</div>
+
+		<div class="status-tabs" role="tablist" aria-label="Filter by status">
+			{#each statusFilters as filter (filter.mode)}
+				<button
+					type="button"
+					role="tab"
+					class:active={filterMode === filter.mode}
+					aria-selected={filterMode === filter.mode}
+					onclick={() => {
+						filterMode = filter.mode;
+					}}
+				>
+					<span>{filter.label}</span>
+					<small>{getFilterCount(filter.mode)}</small>
+				</button>
+			{/each}
+		</div>
+
+		<div class="folder-strip" aria-label="Extension folders">
+			<button
+				type="button"
+				class:active={activeFolderId === allFolderId}
+				onclick={() => {
+					selectFolder(allFolderId);
+				}}
+			>
+				<span>All</span>
+				<small>{getFolderCount(allFolderId)}</small>
+			</button>
+			<button
+				type="button"
+				class:active={activeFolderId === noFolderId}
+				onclick={() => {
+					selectFolder(noFolderId);
+				}}
+			>
+				<span>No folder</span>
+				<small>{getFolderCount(noFolderId)}</small>
+			</button>
+			{#each folders as folder (folder.id)}
+				<button
+					type="button"
+					class:active={activeFolderId === folder.id}
+					onclick={() => {
+						selectFolder(folder.id);
+					}}
+				>
+					<span>{folder.name}</span>
+					<small>{getFolderCount(folder.id)}</small>
+				</button>
+			{/each}
+		</div>
+
+		{#if organizeMode}
+			<div class="organize-panel">
+				<form
+					class="folder-form"
+					onsubmit={event => {
+						event.preventDefault();
+						handleCreateFolder();
+					}}
+				>
+					<input
+						placeholder="New folder"
+						bind:value={newFolderName}
+						aria-label="New folder name"
+					/>
+					<button type="submit">Add</button>
+				</form>
+				<div class="bulk-actions">
+					<button type="button" onclick={() => handleBulkAction(true)}>
+						Enable all
+					</button>
+					<button type="button" onclick={() => handleBulkAction(false)}>
+						Disable all
+					</button>
+					{#if activeFolderId !== allFolderId && activeFolderId !== noFolderId}
+						<button type="button" class="danger" onclick={handleDeleteFolder}>
+							{deleteFolderArmed ? 'Confirm delete' : 'Delete folder'}
+						</button>
+					{/if}
+				</div>
+			</div>
+		{/if}
+	</section>
+
+	{#if visibleExtensions.length === 0}
+		<section class="empty-state" aria-live="polite">
+			<h2>No extensions found</h2>
+			<p>Try another search or choose another folder.</p>
+		</section>
+	{:else}
+		<section class="extension-groups" aria-label="Extension list">
+			{#each folderSections as section (section.id)}
+				<div class="section-heading">
+					<h2>{section.name}</h2>
+					<span>{section.extensions.length}</span>
+				</div>
+				<ul class="ext-list">
+					{#each section.extensions as extension (extension.id)}
+						<Extension
+							{...extension}
+							bind:enabled={extension.enabled}
+							{folders}
+							{showExtras}
+							{organizeMode}
+							oncontextmenu={onContextMenu}
+							onfolderchange={folderId =>
+								handleFolderChange(extension.id, folderId)}
+							onpin={() => handlePin(extension.id)}
+							{undoStack}
+						/>
+					{/each}
+				</ul>
+			{/each}
+		</section>
+	{/if}
 </main>

--- a/source/app.svelte
+++ b/source/app.svelte
@@ -24,6 +24,7 @@
 	];
 
 	let activeFolderId = $state(allFolderId);
+	let controlsExpanded = $state(false);
 	let deleteFolderArmed = $state(false);
 	let extensions = $state([]);
 	let filterMode = $state('all');
@@ -383,6 +384,10 @@
 			aria-pressed={organizeMode}
 			onclick={() => {
 				organizeMode = !organizeMode;
+				if (organizeMode) {
+					controlsExpanded = true;
+				}
+
 				deleteFolderArmed = false;
 			}}
 		>
@@ -414,105 +419,129 @@
 	{/if}
 
 	<section class="control-panel" aria-label="Extension controls">
-		<div class="search-row">
-			<label class="search-box">
-				<span class="search-label">Search</span>
-				<!-- svelte-ignore a11y_autofocus -->
-				<input
-					autofocus
-					placeholder={message('searchTxt', 'Search by name...')}
-					bind:value={searchValue}
-					type="search"
-				/>
-			</label>
-			{#if searchValue}
-				<button type="button" class="clear-search" onclick={clearSearch}>
-					Clear
-				</button>
-			{/if}
-		</div>
+		<button
+			type="button"
+			class="panel-summary"
+			aria-expanded={controlsExpanded}
+			aria-controls="extension-controls"
+			onclick={() => {
+				controlsExpanded = !controlsExpanded;
+			}}
+		>
+			<span>
+				<strong>Search and filters</strong>
+				<small>{visibleExtensions.length} shown</small>
+			</span>
+			<span class="dropdown-arrow" aria-hidden="true"></span>
+		</button>
 
-		<div class="status-tabs" role="tablist" aria-label="Filter by status">
-			{#each statusFilters as filter (filter.mode)}
-				<button
-					type="button"
-					role="tab"
-					class:active={filterMode === filter.mode}
-					aria-selected={filterMode === filter.mode}
-					onclick={() => {
-						filterMode = filter.mode;
-					}}
-				>
-					<span>{filter.label}</span>
-					<small>{getFilterCount(filter.mode)}</small>
-				</button>
-			{/each}
-		</div>
-
-		<div class="folder-strip" aria-label="Extension folders">
-			<button
-				type="button"
-				class:active={activeFolderId === allFolderId}
-				onclick={() => {
-					selectFolder(allFolderId);
-				}}
-			>
-				<span>All</span>
-				<small>{getFolderCount(allFolderId)}</small>
-			</button>
-			<button
-				type="button"
-				class:active={activeFolderId === noFolderId}
-				onclick={() => {
-					selectFolder(noFolderId);
-				}}
-			>
-				<span>No folder</span>
-				<small>{getFolderCount(noFolderId)}</small>
-			</button>
-			{#each folders as folder (folder.id)}
-				<button
-					type="button"
-					class:active={activeFolderId === folder.id}
-					onclick={() => {
-						selectFolder(folder.id);
-					}}
-				>
-					<span>{folder.name}</span>
-					<small>{getFolderCount(folder.id)}</small>
-				</button>
-			{/each}
-		</div>
-
-		{#if organizeMode}
-			<div class="organize-panel">
-				<form
-					class="folder-form"
-					onsubmit={event => {
-						event.preventDefault();
-						handleCreateFolder();
-					}}
-				>
-					<input
-						placeholder="New folder"
-						bind:value={newFolderName}
-						aria-label="New folder name"
-					/>
-					<button type="submit">Add</button>
-				</form>
-				<div class="bulk-actions">
-					<button type="button" onclick={() => handleBulkAction(true)}>
-						Enable all
-					</button>
-					<button type="button" onclick={() => handleBulkAction(false)}>
-						Disable all
-					</button>
-					{#if activeFolderId !== allFolderId && activeFolderId !== noFolderId}
-						<button type="button" class="danger" onclick={handleDeleteFolder}>
-							{deleteFolderArmed ? 'Confirm delete' : 'Delete folder'}
+		{#if controlsExpanded}
+			<div id="extension-controls" class="control-panel-body">
+				<div class="search-row">
+					<label class="search-box">
+						<span class="search-label">Search</span>
+						<!-- svelte-ignore a11y_autofocus -->
+						<input
+							autofocus
+							placeholder={message('searchTxt', 'Search by name...')}
+							bind:value={searchValue}
+							type="search"
+						/>
+					</label>
+					{#if searchValue}
+						<button type="button" class="clear-search" onclick={clearSearch}>
+							Clear
 						</button>
 					{/if}
 				</div>
+
+				<div class="status-tabs" role="tablist" aria-label="Filter by status">
+					{#each statusFilters as filter (filter.mode)}
+						<button
+							type="button"
+							role="tab"
+							class:active={filterMode === filter.mode}
+							aria-selected={filterMode === filter.mode}
+							onclick={() => {
+								filterMode = filter.mode;
+							}}
+						>
+							<span>{filter.label}</span>
+							<small>{getFilterCount(filter.mode)}</small>
+						</button>
+					{/each}
+				</div>
+
+				<div class="folder-strip" aria-label="Extension folders">
+					<button
+						type="button"
+						class:active={activeFolderId === allFolderId}
+						onclick={() => {
+							selectFolder(allFolderId);
+						}}
+					>
+						<span>All</span>
+						<small>{getFolderCount(allFolderId)}</small>
+					</button>
+					<button
+						type="button"
+						class:active={activeFolderId === noFolderId}
+						onclick={() => {
+							selectFolder(noFolderId);
+						}}
+					>
+						<span>No folder</span>
+						<small>{getFolderCount(noFolderId)}</small>
+					</button>
+					{#each folders as folder (folder.id)}
+						<button
+							type="button"
+							class:active={activeFolderId === folder.id}
+							onclick={() => {
+								selectFolder(folder.id);
+							}}
+						>
+							<span>{folder.name}</span>
+							<small>{getFolderCount(folder.id)}</small>
+						</button>
+					{/each}
+				</div>
+
+				{#if organizeMode}
+					<div class="organize-panel">
+						<form
+							class="folder-form"
+							onsubmit={event => {
+								event.preventDefault();
+								handleCreateFolder();
+							}}
+						>
+							<input
+								placeholder="New folder"
+								bind:value={newFolderName}
+								aria-label="New folder name"
+							/>
+							<button type="submit">Add</button>
+						</form>
+						<div class="bulk-actions">
+							<button type="button" onclick={() => handleBulkAction(true)}>
+								Enable all
+							</button>
+							<button type="button" onclick={() => handleBulkAction(false)}>
+								Disable all
+							</button>
+							{#if activeFolderId !== allFolderId && activeFolderId !== noFolderId}
+								<button
+									type="button"
+									class="danger"
+									onclick={handleDeleteFolder}
+								>
+									{deleteFolderArmed ? 'Confirm delete' : 'Delete folder'}
+								</button>
+							{/if}
+						</div>
+					</div>
+				{/if}
 			</div>
 		{/if}
 	</section>

--- a/source/app.svelte
+++ b/source/app.svelte
@@ -17,6 +17,16 @@
 		!localStorage.getItem('sticky-info-message'),
 	);
 	let showInfoMessage = $state(!localStorage.getItem('undo-info-message'));
+	const visibleExtensions = $derived.by(() => {
+		const keywords = searchValue
+			.toLowerCase()
+			.split(' ')
+			.filter(s => s.length);
+
+		return extensions.filter(extension =>
+			keywords.every(word => extension.indexedName.includes(word)),
+		);
+	});
 
 	// "Disable/enable all" shows the button again, unless the user clicked already "hide" in the current session
 	let userClickedHideInfoMessage = $state(false);
@@ -30,18 +40,6 @@
 
 		if (position === 'popup' || position === 'window') {
 			document.documentElement.style.width = `${width || 400}px`;
-		}
-	});
-
-	$effect(() => {
-		const keywords = searchValue
-			.toLowerCase()
-			.split(' ')
-			.filter(s => s.length);
-		for (const extension of extensions) {
-			extension.shown = keywords.every(word =>
-				extension.indexedName.includes(word),
-			);
 		}
 	});
 
@@ -85,12 +83,25 @@
 
 	function toggleAll(enable) {
 		const affectedExtensions = extensions.filter(
-			extension => enable !== extension.enabled,
+			extension =>
+				enable !== extension.enabled &&
+				(enable
+					? extension.mayEnable !== false
+					: extension.mayDisable !== false),
 		);
 
 		undoStack.do(toggle => {
 			for (const extension of affectedExtensions) {
-				chrome.management.setEnabled(extension.id, enable ? toggle : !toggle);
+				chrome.management.setEnabled(
+					extension.id,
+					enable ? toggle : !toggle,
+					() => {
+						const failure = chrome.runtime.lastError?.message;
+						if (failure) {
+							console.warn('Failed to update extension state:', failure);
+						}
+					},
+				);
 			}
 		});
 	}
@@ -107,11 +118,19 @@
 
 	function handleEnabled(updated) {
 		const extension = extensions.find(({id}) => id === updated.id);
+		if (!extension) {
+			return;
+		}
+
 		extension.enabled = true;
 	}
 
 	function handleDisabled(updated) {
 		const extension = extensions.find(({id}) => id === updated.id);
+		if (!extension) {
+			return;
+		}
+
 		extension.enabled = false;
 	}
 
@@ -211,17 +230,15 @@
 		</select>
 	</div>
 	<ul id="ext-list">
-		{#each extensions as extension (extension.id)}
-			{#if extension.shown}
-				<Extension
-					{...extension}
-					bind:enabled={extension.enabled}
-					bind:showExtras
-					oncontextmenu={onContextMenu}
-					onpin={() => handlePin(extension.id)}
-					{undoStack}
-				/>
-			{/if}
+		{#each visibleExtensions as extension (extension.id)}
+			<Extension
+				{...extension}
+				bind:enabled={extension.enabled}
+				bind:showExtras
+				oncontextmenu={onContextMenu}
+				onpin={() => handlePin(extension.id)}
+				{undoStack}
+			/>
 		{/each}
 	</ul>
 </main>

--- a/source/app.svelte
+++ b/source/app.svelte
@@ -169,16 +169,6 @@
 				break;
 			}
 
-			case 'extensions': {
-				chrome.tabs.create({url: 'chrome://extensions'});
-				break;
-			}
-
-			case 'options': {
-				chrome.runtime.openOptionsPage();
-				break;
-			}
-
 			default:
 		}
 
@@ -216,8 +206,6 @@
 		/>
 		<select class="header-burger" onchange={handleBurger}>
 			<option value=""></option>
-			<option value="options">{getI18N('gotoOpt')}</option>
-			<option value="extensions">{getI18N('manage')}</option>
 			<option value="disable">{getI18N('disAll')}</option>
 			<option value="enable">{getI18N('enableAll')}</option>
 		</select>

--- a/source/background.js
+++ b/source/background.js
@@ -1,23 +1,83 @@
 import optionsStorage, {matchOptions} from './options-storage.js';
 
-matchOptions();
+const nativeHostName = 'com.ocem.popuphost';
+
+function isValidExtensionId(extensionId) {
+	return /^[a-p]{32}$/v.test(extensionId);
+}
+
+function isTrustedSender(sender) {
+	return (
+		sender.id === chrome.runtime.id ||
+		sender.origin === chrome.runtime.getURL('').slice(0, -1)
+	);
+}
+
+function handleNativePopupRequest(message, sender, sendResponse) {
+	if (message?.type !== 'open-extension-popup') {
+		return false;
+	}
+
+	if (!isTrustedSender(sender)) {
+		sendResponse({ok: false, error: 'Unexpected extension message sender.'});
+		return false;
+	}
+
+	if (
+		!isValidExtensionId(message.extensionId) ||
+		typeof message.extensionName !== 'string' ||
+		message.extensionName.trim() === ''
+	) {
+		sendResponse({ok: false, error: 'Invalid extension popup request.'});
+		return false;
+	}
+
+	chrome.runtime.sendNativeMessage(
+		nativeHostName,
+		{
+			type: 'open-extension-popup',
+			extensionId: message.extensionId,
+			extensionName: message.extensionName,
+		},
+		response => {
+			const failure = chrome.runtime.lastError?.message;
+			if (failure) {
+				sendResponse({ok: false, error: failure});
+				return;
+			}
+
+			sendResponse(
+				response?.ok
+					? response
+					: {ok: false, error: 'Native host returned an invalid response.'},
+			);
+		},
+	);
+
+	return true;
+}
+
+function syncActionMode() {
+	matchOptions().catch(error => {
+		console.warn('Failed to sync action mode:', error);
+	});
+}
+
+syncActionMode();
 optionsStorage.onChanged((current, old) => {
 	if (old.position !== current.position) {
-		matchOptions();
+		syncActionMode();
 	}
 });
+
+chrome.runtime.onMessage.addListener(handleNativePopupRequest);
+chrome.runtime.onMessageExternal.addListener(handleNativePopupRequest);
 
 // Must be registered on the top level
 chrome.action.onClicked.addListener(async () => {
 	let {position, width} = await optionsStorage.getAll();
 
 	// 'popup' and 'sidebar' are handled by the browser
-
-	if (position === 'tab') {
-		chrome.tabs.create({url: chrome.runtime.getURL('index.html')});
-		return;
-	}
-
 	if (position === 'window') {
 		width = width === '' ? 400 : Number.parseInt(width, 10); // Must be an integer
 		const height = 600;
@@ -32,6 +92,3 @@ chrome.action.onClicked.addListener(async () => {
 		});
 	}
 });
-
-// DEVELOPMENT MODE: uncomment this so the tab will reopen on extension reload
-// chrome.tabs.create({url: chrome.runtime.getURL('index.html')});

--- a/source/background.js
+++ b/source/background.js
@@ -76,23 +76,3 @@ optionsStorage.onChanged((current, old) => {
 
 chrome.runtime.onMessage.addListener(handleNativePopupRequest);
 chrome.runtime.onMessageExternal.addListener(handleNativePopupRequest);
-
-// Must be registered on the top level
-chrome.action.onClicked.addListener(async () => {
-	let {position, width} = await optionsStorage.getAll();
-
-	// 'popup' and 'sidebar' are handled by the browser
-	if (position === 'window') {
-		width = width === '' ? 400 : Number.parseInt(width, 10); // Must be an integer
-		const height = 600;
-		const currentWindow = await chrome.windows.getCurrent();
-		await chrome.windows.create({
-			type: 'popup',
-			url: chrome.runtime.getURL('index.html?auto-fit=true'),
-			width,
-			height,
-			top: currentWindow.top + Math.round((currentWindow.height - height) / 2),
-			left: currentWindow.left + Math.round((currentWindow.width - width) / 2),
-		});
-	}
-});

--- a/source/background.js
+++ b/source/background.js
@@ -26,7 +26,10 @@ function handleNativePopupRequest(message, sender, sendResponse) {
 	if (
 		!isValidExtensionId(message.extensionId) ||
 		typeof message.extensionName !== 'string' ||
-		message.extensionName.trim() === ''
+		message.extensionName.trim() === '' ||
+		(message.extensionAliases !== undefined &&
+			(!Array.isArray(message.extensionAliases) ||
+				message.extensionAliases.some(alias => typeof alias !== 'string')))
 	) {
 		sendResponse({ok: false, error: 'Invalid extension popup request.'});
 		return false;
@@ -38,6 +41,7 @@ function handleNativePopupRequest(message, sender, sendResponse) {
 			type: 'open-extension-popup',
 			extensionId: message.extensionId,
 			extensionName: message.extensionName,
+			extensionAliases: message.extensionAliases || [],
 		},
 		response => {
 			const failure = chrome.runtime.lastError?.message;

--- a/source/extension.svelte
+++ b/source/extension.svelte
@@ -14,20 +14,36 @@
 		installType,
 		optionsUrl,
 		icons,
-		showExtras = $bindable(),
+		folders = [],
+		folderId = '',
+		folderName = '',
+		showExtras = false,
+		organizeMode = false,
 		undoStack,
 		isPinned = false,
+		onfolderchange,
 		onpin,
 		oncontextmenu,
 	} = $props();
 
 	const getI18N = chrome.i18n.getMessage;
-	// The browser will still fill the "short name" with "name" if missing
+	// The browser will still fill the "short name" with "name" if missing.
 	const realName = $derived(trimName(shortName ?? name));
 	const primaryAction = $derived(getPrimaryAction({enabled, mayEnable}));
+	const statusText = $derived(enabled ? 'Active' : 'Off');
+	const helperText = $derived.by(() => {
+		if (!enabled) {
+			return mayEnable ? 'Click to enable' : 'Disabled by policy';
+		}
+
+		return primaryAction.type === 'popup'
+			? 'Click to open popup'
+			: 'Popup unavailable';
+	});
 
 	let busy = $state(false);
 	let error = $state('');
+	let removeArmed = $state(false);
 
 	function message(key, fallback) {
 		return getI18N(key) || fallback;
@@ -146,10 +162,10 @@
 	}
 
 	function handlePrimaryAction(event) {
-		// Check if Ctrl/Cmd is held down for pinning
+		removeArmed = false;
+
 		if (event.ctrlKey || event.metaKey) {
-			onpin?.();
-			return;
+			return togglePinned();
 		}
 
 		if (primaryAction.type === 'enable') {
@@ -168,35 +184,36 @@
 		return action();
 	}
 
-	function isInteractiveChildEvent(event) {
-		return (
-			event.target !== event.currentTarget &&
-			Boolean(event.target.closest?.('button, a, input, select, textarea'))
-		);
-	}
-
-	function handleRowKeydown(event) {
-		if (isInteractiveChildEvent(event)) {
-			return;
-		}
-
-		if (event.key !== 'Enter' && event.key !== ' ') {
-			return;
-		}
-
-		event.preventDefault();
-		return handlePrimaryAction(event);
-	}
-
 	function handleToggleClick() {
+		removeArmed = false;
 		return runAction(() => setEnabledWithUndo(!enabled));
 	}
 
-	function onUninstallClick() {
-		return runAction(
+	function togglePinned() {
+		removeArmed = false;
+		return runAction(async () => {
+			await onpin?.();
+		});
+	}
+
+	function handleFolderSelect(event) {
+		event.stopPropagation();
+		removeArmed = false;
+		onfolderchange?.(event.currentTarget.value);
+	}
+
+	async function onUninstallClick() {
+		if (!removeArmed) {
+			error = '';
+			removeArmed = true;
+			return;
+		}
+
+		removeArmed = false;
+		await runAction(
 			() =>
 				new Promise((resolve, reject) => {
-					chrome.management.uninstall(id, () => {
+					chrome.management.uninstall(id, {showConfirmDialog: true}, () => {
 						const failure = chrome.runtime.lastError?.message;
 						if (failure) {
 							reject(new Error(failure));
@@ -210,66 +227,131 @@
 	}
 </script>
 
-<!-- svelte-ignore a11y_no_noninteractive_element_to_interactive_role -->
 <li
 	class:disabled={!enabled}
 	class:pinned={isPinned}
+	class:busy
 	class="ext type-{installType}"
-	role="button"
-	tabindex={busy ? -1 : 0}
-	onclick={handlePrimaryAction}
-	onkeydown={handleRowKeydown}
 >
 	<button
 		type="button"
-		class="ext-name"
+		class="ext-main"
 		oncontextmenu={handleContextMenu}
 		title={getPrimaryTitle()}
+		onclick={handlePrimaryAction}
 		disabled={busy}
 	>
-		<img alt="" src={pickBestIcon(icons, 16)} />{realName}
+		<span class="ext-icon">
+			<img alt="" src={pickBestIcon(icons, 32)} />
+		</span>
+		<span class="ext-copy">
+			<span class="ext-title-row">
+				<span class="ext-name">{realName}</span>
+				{#if folderName}
+					<span class="ext-pill folder">{folderName}</span>
+				{/if}
+				{#if isPinned}
+					<span class="ext-pill">Pinned</span>
+				{/if}
+				{#if installType === 'development'}
+					<span class="ext-pill dev">Dev</span>
+				{:else if installType === 'admin'}
+					<span class="ext-pill admin">Admin</span>
+				{/if}
+			</span>
+			<span class="ext-meta">
+				<span class:enabled class="status-dot"></span>
+				<span>{statusText}</span>
+				<span class="meta-divider">/</span>
+				<span>{helperText}</span>
+			</span>
+		</span>
 	</button>
-	<button
-		type="button"
-		class="ext-toggle"
-		class:enabled
-		role="switch"
-		aria-checked={enabled}
-		aria-label={getToggleTitle()}
-		title={getToggleTitle()}
-		onclick={event => runSecondaryAction(event, handleToggleClick)}
-		disabled={busy || !canToggle()}
-	>
-		<span class="ext-toggle-knob"></span>
-	</button>
-	{#if showExtras}
-		{#if optionsUrl && enabled}
+
+	<div class="ext-actions">
+		{#if organizeMode}
+			<select
+				class="folder-select"
+				aria-label="Move {realName} to folder"
+				onchange={handleFolderSelect}
+				onclick={event => {
+					event.stopPropagation();
+				}}
+			>
+				<option value="" selected={!folderId}>No folder</option>
+				{#each folders as folder (folder.id)}
+					<option value={folder.id} selected={folderId === folder.id}>
+						{folder.name}
+					</option>
+				{/each}
+			</select>
 			<button
 				type="button"
-				title={message('openToolbarPopup', 'Open extension popup')}
-				onclick={event => runSecondaryAction(event, openToolbarPopup)}
+				class="mini-action"
+				class:active={isPinned}
+				title={isPinned ? 'Unpin from top' : 'Pin to top'}
+				onclick={event => runSecondaryAction(event, togglePinned)}
 				disabled={busy}
 			>
-				<img src="icons/options.svg" alt="" />
+				{isPinned ? 'Pinned' : 'Pin'}
 			</button>
+		{:else if showExtras}
+			<button
+				type="button"
+				class="mini-action primary"
+				title={message('openToolbarPopup', 'Open extension popup')}
+				onclick={event => runSecondaryAction(event, openToolbarPopup)}
+				disabled={busy || !enabled}
+			>
+				Open
+			</button>
+			<button
+				type="button"
+				class="mini-action"
+				class:active={isPinned}
+				title={isPinned ? 'Unpin from top' : 'Pin to top'}
+				onclick={event => runSecondaryAction(event, togglePinned)}
+				disabled={busy}
+			>
+				{isPinned ? 'Pinned' : 'Pin'}
+			</button>
+			{#if optionsUrl && enabled}
+				<button
+					type="button"
+					class="icon-action"
+					title={message('openToolbarPopup', 'Open extension popup')}
+					onclick={event => runSecondaryAction(event, openToolbarPopup)}
+					disabled={busy}
+				>
+					<img src="icons/options.svg" alt="" />
+				</button>
+			{/if}
 		{/if}
 		<button
 			type="button"
-			title={message('openToolbarPopup', 'Open extension popup')}
-			onclick={event => runSecondaryAction(event, openToolbarPopup)}
-			disabled={busy || !enabled}
-		>
-			<img src="icons/ellipsis.svg" alt="" />
-		</button>
-		<button
-			type="button"
-			title={getI18N('uninstall')}
+			class="mini-action danger remove-action"
+			class:armed={removeArmed}
+			title={removeArmed ? 'Confirm uninstall' : 'Remove extension'}
 			onclick={event => runSecondaryAction(event, onUninstallClick)}
 			disabled={busy}
 		>
-			<img src="icons/bin.svg" alt="" />
+			{removeArmed ? 'Confirm' : 'Remove'}
 		</button>
-	{/if}
+		<button
+			type="button"
+			class="ext-toggle"
+			class:enabled
+			role="switch"
+			aria-checked={enabled}
+			aria-label={getToggleTitle()}
+			title={getToggleTitle()}
+			onclick={event => runSecondaryAction(event, handleToggleClick)}
+			disabled={busy || !canToggle()}
+		>
+			<span class="ext-toggle-knob"></span>
+		</button>
+	</div>
+
 	{#if error}
 		<p class="ext-error">{error}</p>
 	{/if}

--- a/source/extension.svelte
+++ b/source/extension.svelte
@@ -81,7 +81,7 @@
 					)} ${detail}`
 				: message(
 						'nativeHelperMissing',
-						'Native popup helper is not installed. Run native-helper/install-macos.sh from this repository.',
+						'Native popup helper is not installed. Run npm run helper:install -- <extension-id> brave from this repository.',
 					);
 		}
 

--- a/source/extension.svelte
+++ b/source/extension.svelte
@@ -1,6 +1,7 @@
 <script>
+	import {getPrimaryAction} from './lib/extension-actions.js';
 	import pickBestIcon from './lib/icons.js';
-	import openInTab from './lib/open-in-tab.js';
+	import {openNativePopup, PopupHelperError} from './lib/native-popup.js';
 	import trimName from './lib/trim-name.js';
 
 	const {
@@ -8,6 +9,8 @@
 		name,
 		shortName,
 		enabled = $bindable(),
+		mayDisable = true,
+		mayEnable = true,
 		installType,
 		homepageUrl,
 		updateUrl,
@@ -30,6 +33,10 @@
 	const url = $derived(generateHomeURL());
 	// The browser will still fill the "short name" with "name" if missing
 	const realName = $derived(trimName(shortName ?? name));
+	const primaryAction = $derived(getPrimaryAction({enabled, mayEnable}));
+
+	let busy = $state(false);
+	let error = $state('');
 
 	function generateHomeURL() {
 		if (installType !== 'normal') {
@@ -41,6 +48,87 @@
 			: chromeWebStoreUrl;
 	}
 
+	function message(key, fallback) {
+		return getI18N(key) || fallback;
+	}
+
+	function getPrimaryTitle() {
+		if (primaryAction.type === 'enable') {
+			return message('enableExtension', 'Enable extension');
+		}
+
+		if (primaryAction.type === 'popup') {
+			return message('useExtension', 'Open extension popup');
+		}
+
+		return message('extensionMenuUnavailable', 'Extension menu unavailable');
+	}
+
+	function formatError(error_) {
+		if (error_ instanceof PopupHelperError) {
+			const detail = error_.details.at(-1);
+			return detail
+				? `${message(
+						'nativeHelperOpenFailed',
+						'Native popup helper could not open this extension popup.',
+					)} ${detail}`
+				: message(
+						'nativeHelperMissing',
+						'Native popup helper is not installed. Run native-helper/install-macos.sh from this repository.',
+					);
+		}
+
+		return (
+			error_?.message ||
+			message('nativeHelperFailed', 'Extension action failed.')
+		);
+	}
+
+	async function runAction(action) {
+		if (busy) {
+			return;
+		}
+
+		busy = true;
+		error = '';
+		try {
+			await action();
+		} catch (error_) {
+			error = formatError(error_);
+		} finally {
+			busy = false;
+		}
+	}
+
+	function setEnabledWithUndo(nextEnabled) {
+		const previousEnabled = enabled;
+
+		return new Promise((resolve, reject) => {
+			let pending = true;
+			undoStack.do(toggle => {
+				const targetEnabled = toggle ? nextEnabled : previousEnabled;
+				chrome.management.setEnabled(id, targetEnabled, () => {
+					const failure = chrome.runtime.lastError?.message;
+					if (!pending) {
+						if (failure) {
+							console.warn('Failed to update extension state:', failure);
+						}
+
+						return;
+					}
+
+					pending = false;
+					if (failure) {
+						reject(new Error(failure));
+						return;
+					}
+
+					resolve();
+				});
+			});
+		});
+	}
+
 	let contextMenuFired = false;
 
 	function handleContextMenu(event) {
@@ -50,61 +138,144 @@
 		}
 	}
 
-	function toggleExtension(event) {
+	function openToolbarPopup() {
+		return runAction(async () => {
+			if (!enabled) {
+				throw new Error(
+					message('extensionMenuUnavailable', 'Extension menu unavailable'),
+				);
+			}
+
+			await openNativePopup({
+				extensionId: id,
+				extensionName: realName,
+			});
+		});
+	}
+
+	function handlePrimaryAction(event) {
 		// Check if Ctrl/Cmd is held down for pinning
 		if (event.ctrlKey || event.metaKey) {
 			onpin?.();
 			return;
 		}
 
-		const wasEnabled = enabled;
-		undoStack.do(toggle => {
-			chrome.management.setEnabled(id, toggle !== wasEnabled);
-		});
+		if (primaryAction.type === 'enable') {
+			return runAction(() => setEnabledWithUndo(true));
+		}
+
+		if (primaryAction.type === 'popup') {
+			return openToolbarPopup();
+		}
+
+		error = message('extensionMenuUnavailable', 'Extension menu unavailable');
+	}
+
+	function runSecondaryAction(event, action) {
+		event.stopPropagation();
+		return action();
+	}
+
+	function handleRowKeydown(event) {
+		if (event.key !== 'Enter' && event.key !== ' ') {
+			return;
+		}
+
+		event.preventDefault();
+		return handlePrimaryAction(event);
+	}
+
+	function handleToggleClick() {
+		return runAction(() => setEnabledWithUndo(!enabled));
 	}
 
 	function onUninstallClick() {
-		chrome.management.uninstall(id);
+		return runAction(
+			() =>
+				new Promise((resolve, reject) => {
+					chrome.management.uninstall(id, () => {
+						const failure = chrome.runtime.lastError?.message;
+						if (failure) {
+							reject(new Error(failure));
+							return;
+						}
+
+						resolve();
+					});
+				}),
+		);
 	}
 </script>
 
+<!-- svelte-ignore a11y_no_noninteractive_element_to_interactive_role -->
 <li
 	class:disabled={!enabled}
 	class:pinned={isPinned}
 	class="ext type-{installType}"
+	role="button"
+	tabindex={busy ? -1 : 0}
+	onclick={handlePrimaryAction}
+	onkeydown={handleRowKeydown}
 >
 	<button
 		type="button"
 		class="ext-name"
-		onclick={toggleExtension}
 		oncontextmenu={handleContextMenu}
+		title={getPrimaryTitle()}
+		disabled={busy}
 	>
 		<img alt="" src={pickBestIcon(icons, 16)} />{realName}
 	</button>
-	{#if optionsUrl && enabled}
-		<a href={optionsUrl} title={getI18N('gotoOpt')} onclick={openInTab}>
-			<img src="icons/options.svg" alt="" />
-		</a>
-	{/if}
 	{#if showExtras}
+		<button
+			type="button"
+			title={enabled
+				? message('disableExtension', 'Disable extension')
+				: message('enableExtension', 'Enable extension')}
+			onclick={event => runSecondaryAction(event, handleToggleClick)}
+			disabled={busy || (enabled && !mayDisable)}
+		>
+			<img src="icons/power.svg" alt="" />
+		</button>
+		{#if optionsUrl && enabled}
+			<button
+				type="button"
+				title={message('openToolbarPopup', 'Open extension popup')}
+				onclick={event => runSecondaryAction(event, openToolbarPopup)}
+				disabled={busy}
+			>
+				<img src="icons/options.svg" alt="" />
+			</button>
+		{/if}
 		{#if url}
-			<a href={url} title={getI18N('openUrl')} target="_blank" rel="noreferrer">
+			<a
+				href={url}
+				title={getI18N('openUrl')}
+				target="_blank"
+				rel="noreferrer"
+				onclick={event => event.stopPropagation()}
+			>
 				<img src="icons/globe.svg" alt="" />
 			</a>
 		{/if}
-		<a
-			href="chrome://extensions/?id={id}"
-			title={getI18N('manage')}
-			onclick={openInTab}
+		<button
+			type="button"
+			title={message('openToolbarPopup', 'Open extension popup')}
+			onclick={event => runSecondaryAction(event, openToolbarPopup)}
+			disabled={busy || !enabled}
 		>
 			<img src="icons/ellipsis.svg" alt="" />
-		</a>
+		</button>
 		<button
 			type="button"
 			title={getI18N('uninstall')}
-			onclick={onUninstallClick}
+			onclick={event => runSecondaryAction(event, onUninstallClick)}
+			disabled={busy}
 		>
 			<img src="icons/bin.svg" alt="" />
 		</button>
+	{/if}
+	{#if error}
+		<p class="ext-error">{error}</p>
 	{/if}
 </li>

--- a/source/extension.svelte
+++ b/source/extension.svelte
@@ -12,8 +12,6 @@
 		mayDisable = true,
 		mayEnable = true,
 		installType,
-		homepageUrl,
-		updateUrl,
 		optionsUrl,
 		icons,
 		showExtras = $bindable(),
@@ -24,29 +22,12 @@
 	} = $props();
 
 	const getI18N = chrome.i18n.getMessage;
-	const chromeWebStoreUrl = $derived(
-		`https://chrome.google.com/webstore/detail/${id}`,
-	);
-	const edgeWebStoreUrl = $derived(
-		`https://microsoftedge.microsoft.com/addons/detail/${id}`,
-	);
-	const url = $derived(generateHomeURL());
 	// The browser will still fill the "short name" with "name" if missing
 	const realName = $derived(trimName(shortName ?? name));
 	const primaryAction = $derived(getPrimaryAction({enabled, mayEnable}));
 
 	let busy = $state(false);
 	let error = $state('');
-
-	function generateHomeURL() {
-		if (installType !== 'normal') {
-			return homepageUrl;
-		}
-
-		return updateUrl?.startsWith('https://edge.microsoft.com')
-			? edgeWebStoreUrl
-			: chromeWebStoreUrl;
-	}
 
 	function message(key, fallback) {
 		return getI18N(key) || fallback;
@@ -271,17 +252,6 @@
 			>
 				<img src="icons/options.svg" alt="" />
 			</button>
-		{/if}
-		{#if url}
-			<a
-				href={url}
-				title={getI18N('openUrl')}
-				target="_blank"
-				rel="noreferrer"
-				onclick={event => event.stopPropagation()}
-			>
-				<img src="icons/globe.svg" alt="" />
-			</a>
 		{/if}
 		<button
 			type="button"

--- a/source/extension.svelte
+++ b/source/extension.svelte
@@ -64,9 +64,19 @@
 		return message('extensionMenuUnavailable', 'Extension menu unavailable');
 	}
 
+	function getToggleTitle() {
+		return enabled
+			? message('disableExtension', 'Disable extension')
+			: message('enableExtension', 'Enable extension');
+	}
+
+	function canToggle() {
+		return enabled ? mayDisable : mayEnable;
+	}
+
 	function formatError(error_) {
 		if (error_ instanceof PopupHelperError) {
-			const detail = error_.details.at(-1);
+			const detail = error_.details.join(' ');
 			return detail
 				? `${message(
 						'nativeHelperOpenFailed',
@@ -149,6 +159,7 @@
 			await openNativePopup({
 				extensionId: id,
 				extensionName: realName,
+				extensionAliases: [name, shortName].filter(Boolean),
 			});
 		});
 	}
@@ -176,7 +187,18 @@
 		return action();
 	}
 
+	function isInteractiveChildEvent(event) {
+		return (
+			event.target !== event.currentTarget &&
+			Boolean(event.target.closest?.('button, a, input, select, textarea'))
+		);
+	}
+
 	function handleRowKeydown(event) {
+		if (isInteractiveChildEvent(event)) {
+			return;
+		}
+
 		if (event.key !== 'Enter' && event.key !== ' ') {
 			return;
 		}
@@ -226,17 +248,20 @@
 	>
 		<img alt="" src={pickBestIcon(icons, 16)} />{realName}
 	</button>
+	<button
+		type="button"
+		class="ext-toggle"
+		class:enabled
+		role="switch"
+		aria-checked={enabled}
+		aria-label={getToggleTitle()}
+		title={getToggleTitle()}
+		onclick={event => runSecondaryAction(event, handleToggleClick)}
+		disabled={busy || !canToggle()}
+	>
+		<span class="ext-toggle-knob"></span>
+	</button>
 	{#if showExtras}
-		<button
-			type="button"
-			title={enabled
-				? message('disableExtension', 'Disable extension')
-				: message('enableExtension', 'Enable extension')}
-			onclick={event => runSecondaryAction(event, handleToggleClick)}
-			disabled={busy || (enabled && !mayDisable)}
-		>
-			<img src="icons/power.svg" alt="" />
-		</button>
 		{#if optionsUrl && enabled}
 			<button
 				type="button"

--- a/source/icons/power.svg
+++ b/source/icons/power.svg
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round">
-	<path d="M12 2v10" />
-	<path d="M18.4 6.6a9 9 0 1 1-12.8 0" />
-</svg>

--- a/source/icons/power.svg
+++ b/source/icons/power.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round">
+	<path d="M12 2v10" />
+	<path d="M18.4 6.6a9 9 0 1 1-12.8 0" />
+</svg>

--- a/source/index.html
+++ b/source/index.html
@@ -1,4 +1,4 @@
 <!doctype html>
-<title>One Click Extensions Manager</title>
+<title>OnFire Extensions Manager</title>
 <link href="style.css" rel="stylesheet" />
 <script type="module" src="main.js"></script>

--- a/source/lib/action-mode.js
+++ b/source/lib/action-mode.js
@@ -1,0 +1,5 @@
+export const actionPopupPosition = 'popup';
+
+export function normalizeActionPosition(position) {
+	return position === actionPopupPosition ? position : actionPopupPosition;
+}

--- a/source/lib/action-mode.test.js
+++ b/source/lib/action-mode.test.js
@@ -1,0 +1,9 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {actionPopupPosition, normalizeActionPosition} from './action-mode.js';
+
+test('normalizes every legacy action mode to the browser popup', () => {
+	for (const position of ['popup', 'tab', 'window', 'sidebar', '', undefined]) {
+		assert.equal(normalizeActionPosition(position), actionPopupPosition);
+	}
+});

--- a/source/lib/extension-actions.js
+++ b/source/lib/extension-actions.js
@@ -1,0 +1,9 @@
+export function getPrimaryAction(extension) {
+	if (!extension.enabled) {
+		return extension.mayEnable === false
+			? {type: 'unavailable'}
+			: {type: 'enable'};
+	}
+
+	return {type: 'popup'};
+}

--- a/source/lib/extension-actions.test.js
+++ b/source/lib/extension-actions.test.js
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {getPrimaryAction} from './extension-actions.js';
+
+test('opens popup for enabled extensions even when options or launch urls exist', () => {
+	assert.deepEqual(
+		getPrimaryAction({
+			enabled: true,
+			optionsUrl: 'chrome-extension://example/options.html',
+			homepageUrl: 'https://example.com',
+		}),
+		{type: 'popup'},
+	);
+});
+
+test('enables disabled extensions when allowed', () => {
+	assert.deepEqual(getPrimaryAction({enabled: false, mayEnable: true}), {
+		type: 'enable',
+	});
+});
+
+test('marks disabled extensions unavailable when they cannot be enabled', () => {
+	assert.deepEqual(getPrimaryAction({enabled: false, mayEnable: false}), {
+		type: 'unavailable',
+	});
+});

--- a/source/lib/native-popup.js
+++ b/source/lib/native-popup.js
@@ -1,0 +1,129 @@
+export const nativeHostName = 'com.ocem.popuphost';
+
+const localHelperUrl = 'http://127.0.0.1:17645/open-extension-popup';
+
+export class PopupHelperError extends Error {
+	constructor(message, details = []) {
+		super(message);
+		this.name = 'PopupHelperError';
+		this.details = details;
+	}
+}
+
+function getLastErrorMessage() {
+	return chrome.runtime.lastError?.message;
+}
+
+function sendRuntimeMessage(payload, external = false) {
+	return new Promise((resolve, reject) => {
+		const callback = response => {
+			const error = getLastErrorMessage();
+			if (error) {
+				reject(new Error(error));
+				return;
+			}
+
+			resolve(response);
+		};
+
+		if (external) {
+			chrome.runtime.sendMessage(chrome.runtime.id, payload, callback);
+			return;
+		}
+
+		chrome.runtime.sendMessage(payload, callback);
+	});
+}
+
+function sendNativeMessage(payload) {
+	return new Promise((resolve, reject) => {
+		chrome.runtime.sendNativeMessage(nativeHostName, payload, response => {
+			const error = getLastErrorMessage();
+			if (error) {
+				reject(new Error(error));
+				return;
+			}
+
+			resolve(response);
+		});
+	});
+}
+
+async function postLocalHelper(payload) {
+	const controller = new AbortController();
+	const timeout = setTimeout(() => {
+		controller.abort();
+	}, 5000);
+
+	try {
+		const response = await fetch(localHelperUrl, {
+			method: 'POST',
+			headers: {
+				'content-type': 'application/json',
+			},
+			body: JSON.stringify(payload),
+			signal: controller.signal,
+		});
+
+		const data = await response.json().catch(() => ({}));
+		if (!response.ok) {
+			throw new Error(
+				data.error || `Local helper failed with HTTP ${response.status}`,
+			);
+		}
+
+		return data;
+	} catch (error) {
+		throw new Error('Local native helper request failed.', {cause: error});
+	} finally {
+		clearTimeout(timeout);
+	}
+}
+
+function assertOkResponse(response, transport) {
+	if (response?.ok) {
+		return response;
+	}
+
+	throw new Error(
+		response?.error || `${transport} returned an invalid response.`,
+	);
+}
+
+function describeError(error) {
+	if (error?.cause?.message) {
+		return `${error.message} ${error.cause.message}`;
+	}
+
+	return error?.message || String(error);
+}
+
+export async function openNativePopup({extensionId, extensionName}) {
+	const payload = {
+		type: 'open-extension-popup',
+		extensionId,
+		extensionName,
+	};
+
+	const attempts = [
+		['native messaging', () => sendNativeMessage(payload)],
+		['background bridge', () => sendRuntimeMessage(payload)],
+		['external background bridge', () => sendRuntimeMessage(payload, true)],
+		['local helper', () => postLocalHelper(payload)],
+	];
+	const failures = [];
+
+	for (const [transport, run] of attempts) {
+		try {
+			// eslint-disable-next-line no-await-in-loop -- Ordered fallbacks; only try the next transport after a concrete failure.
+			return assertOkResponse(await run(), transport);
+		} catch (error) {
+			failures.push(`${transport}: ${describeError(error)}`);
+		}
+	}
+
+	throw new PopupHelperError(
+		'Native popup helper is not installed or is not responding.',
+		failures,
+	);
+}

--- a/source/lib/native-popup.js
+++ b/source/lib/native-popup.js
@@ -98,11 +98,16 @@ function describeError(error) {
 	return error?.message || String(error);
 }
 
-export async function openNativePopup({extensionId, extensionName}) {
+export async function openNativePopup({
+	extensionId,
+	extensionName,
+	extensionAliases = [],
+}) {
 	const payload = {
 		type: 'open-extension-popup',
 		extensionId,
 		extensionName,
+		extensionAliases,
 	};
 
 	const attempts = [

--- a/source/lib/native-popup.test.js
+++ b/source/lib/native-popup.test.js
@@ -1,10 +1,17 @@
-import test from 'node:test';
+import test, {afterEach} from 'node:test';
 import assert from 'node:assert/strict';
 import {
 	openNativePopup,
 	PopupHelperError,
 	nativeHostName,
 } from './native-popup.js';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+	delete globalThis.chrome;
+});
 
 function installChromeMock({nativeMessaging, runtimeMessaging}) {
 	globalThis.chrome = {
@@ -21,7 +28,7 @@ function installChromeMock({nativeMessaging, runtimeMessaging}) {
 	};
 }
 
-test('uses direct native messaging when it succeeds', async () => {
+test('uses direct native messaging before fallbacks', async () => {
 	installChromeMock({
 		nativeMessaging({hostName, payload, callback}) {
 			assert.equal(hostName, nativeHostName);
@@ -29,9 +36,12 @@ test('uses direct native messaging when it succeeds', async () => {
 			callback({ok: true, detail: 'native'});
 		},
 		runtimeMessaging() {
-			assert.fail('runtime messaging should not run after native success');
+			assert.fail('runtime messaging should not run after native messaging success');
 		},
 	});
+	globalThis.fetch = async () => {
+		assert.fail('local helper should not run after native messaging success');
+	};
 
 	assert.deepEqual(
 		await openNativePopup({

--- a/source/lib/native-popup.test.js
+++ b/source/lib/native-popup.test.js
@@ -37,6 +37,7 @@ test('uses direct native messaging when it succeeds', async () => {
 		await openNativePopup({
 			extensionId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
 			extensionName: 'Example',
+			extensionAliases: ['Example Full Name'],
 		}),
 		{ok: true, detail: 'native'},
 	);
@@ -68,11 +69,13 @@ test('falls back to the local helper when native transports fail', async () => {
 		await openNativePopup({
 			extensionId: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
 			extensionName: 'Fallback',
+			extensionAliases: ['Fallback Long Name'],
 		}),
 		{ok: true, detail: 'local'},
 	);
 	assert.equal(calls.length, 1);
 	assert.equal(calls[0].body.extensionName, 'Fallback');
+	assert.deepEqual(calls[0].body.extensionAliases, ['Fallback Long Name']);
 });
 
 test('reports structured failures when every transport fails', async () => {

--- a/source/lib/native-popup.test.js
+++ b/source/lib/native-popup.test.js
@@ -1,0 +1,110 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+	openNativePopup,
+	PopupHelperError,
+	nativeHostName,
+} from './native-popup.js';
+
+function installChromeMock({nativeMessaging, runtimeMessaging}) {
+	globalThis.chrome = {
+		runtime: {
+			id: 'manager-extension-id',
+			lastError: undefined,
+			sendNativeMessage(hostName, payload, callback) {
+				nativeMessaging({hostName, payload, callback});
+			},
+			sendMessage(...arguments_) {
+				runtimeMessaging({arguments_, callback: arguments_.at(-1)});
+			},
+		},
+	};
+}
+
+test('uses direct native messaging when it succeeds', async () => {
+	installChromeMock({
+		nativeMessaging({hostName, payload, callback}) {
+			assert.equal(hostName, nativeHostName);
+			assert.equal(payload.type, 'open-extension-popup');
+			callback({ok: true, detail: 'native'});
+		},
+		runtimeMessaging() {
+			assert.fail('runtime messaging should not run after native success');
+		},
+	});
+
+	assert.deepEqual(
+		await openNativePopup({
+			extensionId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+			extensionName: 'Example',
+		}),
+		{ok: true, detail: 'native'},
+	);
+});
+
+test('falls back to the local helper when native transports fail', async () => {
+	const calls = [];
+	installChromeMock({
+		nativeMessaging({callback}) {
+			chrome.runtime.lastError = {message: 'native missing'};
+			callback();
+			chrome.runtime.lastError = undefined;
+		},
+		runtimeMessaging({callback}) {
+			chrome.runtime.lastError = {message: 'background unavailable'};
+			callback();
+			chrome.runtime.lastError = undefined;
+		},
+	});
+	globalThis.fetch = async (url, options) => {
+		calls.push({url, body: JSON.parse(options.body)});
+		return {
+			ok: true,
+			json: async () => ({ok: true, detail: 'local'}),
+		};
+	};
+
+	assert.deepEqual(
+		await openNativePopup({
+			extensionId: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+			extensionName: 'Fallback',
+		}),
+		{ok: true, detail: 'local'},
+	);
+	assert.equal(calls.length, 1);
+	assert.equal(calls[0].body.extensionName, 'Fallback');
+});
+
+test('reports structured failures when every transport fails', async () => {
+	installChromeMock({
+		nativeMessaging({callback}) {
+			chrome.runtime.lastError = {message: 'native missing'};
+			callback();
+			chrome.runtime.lastError = undefined;
+		},
+		runtimeMessaging({callback}) {
+			chrome.runtime.lastError = {message: 'background unavailable'};
+			callback();
+			chrome.runtime.lastError = undefined;
+		},
+	});
+	globalThis.fetch = async () => ({
+		ok: false,
+		status: 500,
+		json: async () => ({error: 'local failed'}),
+	});
+
+	await assert.rejects(
+		openNativePopup({
+			extensionId: 'cccccccccccccccccccccccccccccccc',
+			extensionName: 'Broken',
+		}),
+		error => {
+			assert.ok(error instanceof PopupHelperError);
+			assert.equal(error.details.length, 4);
+			assert.match(error.details.join('\n'), /native missing/v);
+			assert.match(error.details.join('\n'), /local failed/v);
+			return true;
+		},
+	);
+});

--- a/source/lib/open-in-tab.js
+++ b/source/lib/open-in-tab.js
@@ -1,5 +1,0 @@
-/** Required for chrome:// links */
-export default function openInTab(event) {
-	chrome.tabs.create({url: event.currentTarget.href});
-	event.preventDefault();
-}

--- a/source/lib/prepare-extension-list.js
+++ b/source/lib/prepare-extension-list.js
@@ -1,13 +1,19 @@
 import optionsStorage from '../options-storage.js';
 
-function fillInTheBlanks(extension, isPinned = false) {
+function fillInTheBlanks(extension, {folder, folderId, isPinned = false}) {
 	extension.indexedName = extension.name.toLowerCase();
 	extension.isPinned = isPinned;
+	extension.folderId = folderId;
+	extension.folderName = folder?.name ?? '';
 	return extension;
 }
 
 export default async function prepareExtensionList(extensions) {
-	const {pinnedExtensions} = await optionsStorage.getAll();
+	const {extensionFolderAssignments, extensionFolders, pinnedExtensions} =
+		await optionsStorage.getAll();
+	const foldersById = new Map(
+		extensionFolders.map(folder => [folder.id, folder]),
+	);
 
 	return extensions
 		.filter(({type, id}) => type === 'extension' && id !== chrome.runtime.id)
@@ -27,7 +33,14 @@ export default async function prepareExtensionList(extensions) {
 
 			return a.enabled < b.enabled ? 1 : -1; // Enabled extensions first
 		})
-		.map(extension =>
-			fillInTheBlanks(extension, pinnedExtensions.includes(extension.id)),
-		);
+		.map(extension => {
+			const assignedFolderId = extensionFolderAssignments[extension.id];
+			const folder = foldersById.get(assignedFolderId);
+
+			return fillInTheBlanks(extension, {
+				folder,
+				folderId: folder ? assignedFolderId : '',
+				isPinned: pinnedExtensions.includes(extension.id),
+			});
+		});
 }

--- a/source/lib/prepare-extension-list.js
+++ b/source/lib/prepare-extension-list.js
@@ -1,7 +1,6 @@
 import optionsStorage from '../options-storage.js';
 
 function fillInTheBlanks(extension, isPinned = false) {
-	extension.shown = true;
 	extension.indexedName = extension.name.toLowerCase();
 	extension.isPinned = isPinned;
 	return extension;

--- a/source/manifest.json
+++ b/source/manifest.json
@@ -5,7 +5,8 @@
 	"manifest_version": 3,
 	"homepage_url": "https://github.com/hankxdev/one-click-extensions-manager",
 	"default_locale": "en",
-	"permissions": ["management", "storage", "sidePanel"],
+	"permissions": ["management", "storage", "sidePanel", "nativeMessaging"],
+	"host_permissions": ["http://127.0.0.1:17645/*"],
 	"minimum_chrome_version": "110",
 	"icons": {
 		"16": "logo.png",

--- a/source/manifest.json
+++ b/source/manifest.json
@@ -1,7 +1,8 @@
 {
-	"name": "One Click Extensions Manager V2",
-	"description": "View, use, enable, disable, and remove your extensions with popup support.",
-	"version": "2026.6.16",
+	"name": "OnFire Extensions Manager",
+	"short_name": "OnFire Manager",
+	"description": "OnFire fork of One Click Extension Manager with folders, popups, toggles, and uninstall controls.",
+	"version": "2026.6.17",
 	"manifest_version": 3,
 	"homepage_url": "https://github.com/onfire7777/one-click-extensions-manager-V2",
 	"default_locale": "en",
@@ -9,11 +10,13 @@
 	"host_permissions": ["http://127.0.0.1:17645/*"],
 	"minimum_chrome_version": "110",
 	"icons": {
-		"16": "logo.png",
-		"128": "logo.png"
+		"16": "onfire-logo.svg",
+		"48": "onfire-logo.svg",
+		"128": "onfire-logo.svg"
 	},
 	"action": {
-		"default_icon": "logo.png",
+		"default_title": "OnFire Extensions Manager",
+		"default_icon": "onfire-logo.svg",
 		"default_popup": "index.html"
 	},
 	"side_panel": {

--- a/source/manifest.json
+++ b/source/manifest.json
@@ -1,9 +1,9 @@
 {
-	"name": "__MSG_extName__",
-	"description": "__MSG_extDesc__",
-	"version": "0.0.0",
+	"name": "One Click Extensions Manager V2",
+	"description": "View, use, enable, disable, and remove your extensions with popup support.",
+	"version": "2026.6.16",
 	"manifest_version": 3,
-	"homepage_url": "https://github.com/hankxdev/one-click-extensions-manager",
+	"homepage_url": "https://github.com/onfire7777/one-click-extensions-manager-V2",
 	"default_locale": "en",
 	"permissions": ["management", "storage", "sidePanel", "nativeMessaging"],
 	"host_permissions": ["http://127.0.0.1:17645/*"],

--- a/source/manifest.json
+++ b/source/manifest.json
@@ -5,7 +5,7 @@
 	"manifest_version": 3,
 	"homepage_url": "https://github.com/onfire7777/one-click-extensions-manager-V2",
 	"default_locale": "en",
-	"permissions": ["management", "storage", "sidePanel", "nativeMessaging"],
+	"permissions": ["management", "storage", "nativeMessaging"],
 	"host_permissions": ["http://127.0.0.1:17645/*"],
 	"minimum_chrome_version": "110",
 	"icons": {

--- a/source/onfire-logo.svg
+++ b/source/onfire-logo.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="OnFire Extensions Manager logo">
+	<defs>
+		<linearGradient id="badge" x1="18" y1="12" x2="110" y2="118" gradientUnits="userSpaceOnUse">
+			<stop stop-color="#20293d" />
+			<stop offset="1" stop-color="#111724" />
+		</linearGradient>
+		<linearGradient id="flame" x1="43" y1="24" x2="88" y2="99" gradientUnits="userSpaceOnUse">
+			<stop stop-color="#ffde64" />
+			<stop offset="0.45" stop-color="#ff7a2f" />
+			<stop offset="1" stop-color="#f23030" />
+		</linearGradient>
+		<filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+			<feDropShadow dx="0" dy="6" stdDeviation="5" flood-color="#000" flood-opacity="0.32" />
+		</filter>
+	</defs>
+	<rect x="10" y="9" width="108" height="108" rx="26" fill="url(#badge)" filter="url(#shadow)" />
+	<rect x="12.5" y="11.5" width="103" height="103" rx="24" fill="none" stroke="#ff6535" stroke-width="4" />
+	<rect x="19" y="18" width="90" height="90" rx="19" fill="none" stroke="#ffd25c" stroke-opacity="0.24" stroke-width="2" />
+	<g opacity="0.72">
+		<rect x="31" y="78" width="13" height="13" rx="3" fill="#536987" />
+		<rect x="50" y="78" width="13" height="13" rx="3" fill="#43536f" />
+		<rect x="69" y="78" width="13" height="13" rx="3" fill="#43536f" />
+		<rect x="88" y="78" width="13" height="13" rx="3" fill="#536987" />
+		<rect x="40" y="96" width="13" height="13" rx="3" fill="#43536f" />
+		<rect x="59" y="96" width="13" height="13" rx="3" fill="#536987" />
+		<rect x="78" y="96" width="13" height="13" rx="3" fill="#43536f" />
+	</g>
+	<path fill="url(#flame)" d="M64 21c9 13 15 21 12 33 7-6 14-8 19-5 6 14 3 29-8 39-7 7-15 11-23 12-9-1-17-5-24-12-10-11-11-25-5-38 4-7 11-9 16-17 1-5 4-10 13-12Z" />
+	<path fill="#ffb63d" d="M63 37c7 9 12 18 8 28 4-4 8-6 12-5 4 10 0 20-8 26-5 4-10 6-16 5-8-3-13-9-15-18 0-8 5-12 12-20 1-5 3-10 7-16Z" />
+	<path fill="#ffe06c" d="M62 53c5 6 8 12 6 20 2-2 5-3 7-2 2 7-2 14-8 17-6 2-12-1-14-7-2-8 3-14 9-28Z" />
+	<circle cx="64" cy="65" r="23" fill="none" stroke="#fff" stroke-width="6" stroke-linecap="round" opacity="0.94" />
+	<path d="M70 39v49M70 43h23M70 63h17" fill="none" stroke="#fff" stroke-width="7" stroke-linecap="round" stroke-linejoin="round" />
+	<circle cx="94" cy="35" r="5" fill="#ffdc5f" />
+</svg>

--- a/source/options-storage.js
+++ b/source/options-storage.js
@@ -1,5 +1,8 @@
 import OptionsSync from 'webext-options-sync';
-import {actionPopupPosition, normalizeActionPosition} from './lib/action-mode.js';
+import {
+	actionPopupPosition,
+	normalizeActionPosition,
+} from './lib/action-mode.js';
 
 const optionsStorage = new OptionsSync({
 	defaults: {
@@ -7,6 +10,8 @@ const optionsStorage = new OptionsSync({
 		showButtons: 'on-demand', // Or 'always'
 		width: '',
 		pinnedExtensions: [],
+		extensionFolders: [],
+		extensionFolderAssignments: {},
 	},
 	migrations: [
 		options => {
@@ -44,6 +49,90 @@ export async function togglePin(extensionId) {
 
 	await optionsStorage.set({pinnedExtensions: [...pins]});
 	return pinned;
+}
+
+function normalizeFolderName(name) {
+	return name.trim().replaceAll(/\s+/gv, ' ').slice(0, 32);
+}
+
+function createFolderId() {
+	return `folder-${Date.now().toString(36)}-${Math.random()
+		.toString(36)
+		.slice(2, 8)}`;
+}
+
+export async function createExtensionFolder(name) {
+	const folderName = normalizeFolderName(name);
+	if (!folderName) {
+		throw new Error('Folder name is required.');
+	}
+
+	const {extensionFolders} = await optionsStorage.getAll();
+	const folder = {
+		id: createFolderId(),
+		name: folderName,
+	};
+
+	await optionsStorage.set({extensionFolders: [...extensionFolders, folder]});
+	return folder;
+}
+
+export async function renameExtensionFolder(folderId, name) {
+	const folderName = normalizeFolderName(name);
+	if (!folderName) {
+		throw new Error('Folder name is required.');
+	}
+
+	const {extensionFolders} = await optionsStorage.getAll();
+	await optionsStorage.set({
+		extensionFolders: extensionFolders.map(folder =>
+			folder.id === folderId ? {...folder, name: folderName} : folder,
+		),
+	});
+}
+
+export async function deleteExtensionFolder(folderId) {
+	const {extensionFolders, extensionFolderAssignments} =
+		await optionsStorage.getAll();
+	const assignments = {...extensionFolderAssignments};
+
+	for (const [extensionId, assignedFolderId] of Object.entries(assignments)) {
+		if (assignedFolderId === folderId) {
+			delete assignments[extensionId];
+		}
+	}
+
+	await optionsStorage.set({
+		extensionFolders: extensionFolders.filter(({id}) => id !== folderId),
+		extensionFolderAssignments: assignments,
+	});
+}
+
+export async function assignExtensionFolder(extensionId, folderId) {
+	const {extensionFolders, extensionFolderAssignments} =
+		await optionsStorage.getAll();
+	const assignments = {...extensionFolderAssignments};
+
+	if (!folderId) {
+		delete assignments[extensionId];
+	} else if (extensionFolders.some(({id}) => id === folderId)) {
+		assignments[extensionId] = folderId;
+	}
+
+	await optionsStorage.set({extensionFolderAssignments: assignments});
+}
+
+export async function removeExtensionPreferences(extensionId) {
+	const {extensionFolderAssignments, pinnedExtensions} =
+		await optionsStorage.getAll();
+	const assignments = {...extensionFolderAssignments};
+
+	delete assignments[extensionId];
+
+	await optionsStorage.set({
+		extensionFolderAssignments: assignments,
+		pinnedExtensions: pinnedExtensions.filter(id => id !== extensionId),
+	});
 }
 
 const defaultPopup = chrome.runtime.getManifest().action.default_popup;

--- a/source/options-storage.js
+++ b/source/options-storage.js
@@ -1,16 +1,18 @@
 import OptionsSync from 'webext-options-sync';
+import {actionPopupPosition, normalizeActionPosition} from './lib/action-mode.js';
 
 const optionsStorage = new OptionsSync({
 	defaults: {
-		position: 'popup',
+		position: actionPopupPosition,
 		showButtons: 'on-demand', // Or 'always'
 		width: '',
 		pinnedExtensions: [],
 	},
 	migrations: [
 		options => {
-			if (options.position === 'tab') {
-				options.position = 'popup';
+			const position = normalizeActionPosition(options.position);
+			if (options.position !== position) {
+				options.position = position;
 			}
 		},
 		options => {
@@ -48,16 +50,13 @@ const defaultPopup = chrome.runtime.getManifest().action.default_popup;
 
 export async function matchOptions() {
 	const options = await optionsStorage.getAll();
-	const position = options.position === 'tab' ? 'popup' : options.position;
+	const position = normalizeActionPosition(options.position);
 	if (options.position !== position) {
 		await optionsStorage.set({position});
 	}
 
-	chrome.action.setPopup({popup: position === 'popup' ? defaultPopup : ''});
+	chrome.action.setPopup({popup: defaultPopup});
 
-	const inSidebar = position === 'sidebar';
-	chrome.sidePanel.setOptions({enabled: inSidebar});
-	chrome.sidePanel.setPanelBehavior({
-		openPanelOnActionClick: inSidebar,
-	});
+	chrome.sidePanel?.setOptions?.({enabled: false});
+	chrome.sidePanel?.setPanelBehavior?.({openPanelOnActionClick: false});
 }

--- a/source/options-storage.js
+++ b/source/options-storage.js
@@ -9,6 +9,11 @@ const optionsStorage = new OptionsSync({
 	},
 	migrations: [
 		options => {
+			if (options.position === 'tab') {
+				options.position = 'popup';
+			}
+		},
+		options => {
 			let {width} = options;
 			// Ignore if unset
 			if (!width) {
@@ -42,7 +47,12 @@ export async function togglePin(extensionId) {
 const defaultPopup = chrome.runtime.getManifest().action.default_popup;
 
 export async function matchOptions() {
-	const {position} = await optionsStorage.getAll();
+	const options = await optionsStorage.getAll();
+	const position = options.position === 'tab' ? 'popup' : options.position;
+	if (options.position !== position) {
+		await optionsStorage.set({position});
+	}
+
 	chrome.action.setPopup({popup: position === 'popup' ? defaultPopup : ''});
 
 	const inSidebar = position === 'sidebar';

--- a/source/options/options.html
+++ b/source/options/options.html
@@ -25,8 +25,7 @@
 		ul {
 			padding-left: 1em;
 		}
-		p:has([value='tab']:checked, [value='sidebar']:checked)
-			~ p:has(label[for='width']) {
+		p:has([value='sidebar']:checked) ~ p:has(label[for='width']) {
 			display: none;
 		}
 		fieldset {
@@ -57,10 +56,6 @@
 			<label>
 				<input type="radio" name="position" value="window" />
 				Popup window
-			</label>
-			<label>
-				<input type="radio" name="position" value="tab" />
-				Tab
 			</label>
 			<label>
 				<input type="radio" name="position" value="sidebar" />

--- a/source/options/options.html
+++ b/source/options/options.html
@@ -2,7 +2,7 @@
 <html class="webext-base-css-modal" lang="en">
 	<meta charset="UTF-8" />
 	<base target="_blank" />
-	<title>One Click Extension Manager options</title>
+	<title>One Click Extensions Manager V2 options</title>
 	<style>
 		@import './webext-base.css';
 		body {
@@ -25,9 +25,6 @@
 		ul {
 			padding-left: 1em;
 		}
-		p:has([value='sidebar']:checked) ~ p:has(label[for='width']) {
-			display: none;
-		}
 		fieldset {
 			border: none;
 			padding: 0;
@@ -45,23 +42,9 @@
 		}
 	</style>
 	<script type="module" defer src="options.js"></script>
-	<h1>One-Click Extensions Manager</h1>
+	<h1>One Click Extensions Manager V2</h1>
 	<form id="options-form" method="get">
-		<fieldset>
-			<legend>Location</legend>
-			<label>
-				<input type="radio" checked name="position" value="popup" />
-				Menu (default)
-			</label>
-			<label>
-				<input type="radio" name="position" value="window" />
-				Popup window
-			</label>
-			<label>
-				<input type="radio" name="position" value="sidebar" />
-				Sidebar
-			</label>
-		</fieldset>
+		<input type="hidden" name="position" value="popup" />
 
 		<fieldset>
 			<legend>Show buttons</legend>

--- a/source/options/options.html
+++ b/source/options/options.html
@@ -2,7 +2,7 @@
 <html class="webext-base-css-modal" lang="en">
 	<meta charset="UTF-8" />
 	<base target="_blank" />
-	<title>One Click Extensions Manager V2 options</title>
+	<title>OnFire Extensions Manager options</title>
 	<style>
 		@import './webext-base.css';
 		body {
@@ -14,6 +14,16 @@
 		h1 {
 			font-weight: 100;
 			line-height: 1;
+		}
+		.brand-heading {
+			display: flex;
+			align-items: center;
+			gap: 10px;
+		}
+		.brand-heading img {
+			width: 36px;
+			height: 36px;
+			border-radius: 8px;
 		}
 		label {
 			display: block;
@@ -42,7 +52,10 @@
 		}
 	</style>
 	<script type="module" defer src="options.js"></script>
-	<h1>One Click Extensions Manager V2</h1>
+	<h1 class="brand-heading">
+		<img alt="" height="36" src="../onfire-logo.svg" width="36" />
+		<span>OnFire Extensions Manager</span>
+	</h1>
 	<form id="options-form" method="get">
 		<input type="hidden" name="position" value="popup" />
 
@@ -65,21 +78,19 @@
 	</form>
 	<hr />
 	<p>
-		If you find this useful, consider supporting its development by donating or
-		leaving a review.
+		OnFire Extensions Manager is a modified fork of One Click Extension Manager.
+		Original project credit belongs to Hank Yang and Federico Brigante.
 	</p>
 	<ul>
 		<li>
-			<a
-				href="https://chrome.google.com/webstore/detail/one-click-extensions-mana/pbgjpgbpljobkekbhnnmlikbbfhbhmem/reviews"
-			>
-				Reviews
+			<a href="https://github.com/onfire7777/one-click-extensions-manager-V2">
+				OnFire fork on GitHub
 			</a>
 		</li>
 		<li><a href="https://github.com/sponsors/fregante">Donations</a></li>
 		<li>
 			<a href="https://github.com/hankxdev/one-click-extensions-manager">
-				Open source on GitHub
+				Original One Click Extension Manager
 			</a>
 		</li>
 	</ul>

--- a/source/style.css
+++ b/source/style.css
@@ -1,191 +1,554 @@
-/* RESETS */
 :root {
-	--margin: 8px;
-	--ext-icon-margin: 0.3em;
-	--background-color: light-dark(#fff, #292a2d);
-	--hover-color: #ecf0f1;
-	--pinned-color: #4a9b682e;
-	--development-color: #4170c3;
-	--admin-color: #c32700;
+	--surface: #f7f8fa;
+	--panel: #ffffff;
+	--panel-muted: #eef1f5;
+	--line: #d8dee7;
+	--line-soft: #e7ebf0;
+	--text: #141821;
+	--muted: #667085;
+	--accent: #3867d6;
+	--accent-soft: #e8efff;
+	--success: #1f8b4c;
+	--danger: #c33d33;
+	--danger-soft: #f8e9e7;
 	color-scheme: light dark;
+	font-family:
+		ui-sans-serif,
+		system-ui,
+		-apple-system,
+		BlinkMacSystemFont,
+		'Segoe UI',
+		sans-serif;
 }
 
-body {
-	width: auto;
-	margin: auto;
-	max-width: 800px;
-	padding: var(--margin);
-	direction: auto;
-	background-color: var(--background-color);
-}
-
-main {
-	gap: 1em;
-	display: flex;
-	flex-direction: column;
-}
-
-input {
+* {
 	box-sizing: border-box;
-	width: 100%;
-	padding: 0.2em 0.4em;
+}
+
+html,
+body {
+	min-width: 360px;
+	max-width: 560px;
+	margin: 0;
+	background: var(--surface);
+	color: var(--text);
+	font-size: 14px;
+	line-height: 1.35;
+}
+
+button,
+input,
+select {
+	font: inherit;
+}
+
+button {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: 6px;
+	padding: 0;
+	border: 0;
+	border-radius: 6px;
+	background: none;
+	color: inherit;
+	cursor: pointer;
+}
+
+button:disabled {
+	cursor: not-allowed;
+	opacity: 0.5;
 }
 
 a {
-	outline: 0;
 	color: inherit;
 	text-decoration: none;
 }
 
 kbd {
-	font-family: system-ui, monospace;
+	padding: 1px 5px;
+	border: 1px solid var(--line);
+	border-radius: 5px;
+	background: var(--panel-muted);
+	font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+	font-size: 0.86em;
 }
 
-button {
-	display: inline-block;
-	padding: 0;
+h1,
+h2,
+p {
 	margin: 0;
-	outline: 0;
-	border: none;
-	cursor: pointer;
-	font: inherit;
-	background: none;
-	color: inherit;
-	text-align: start;
 }
 
-a:hover,
-.keyboard-navigation a:focus,
-button:hover,
-.keyboard-navigation button:focus {
-	background-color: var(--hover-color);
-	cursor: pointer;
-}
-
-/**
- * HEADER
- */
-.header {
+.app-shell {
 	display: flex;
-	position: sticky;
-	gap: 0.5em;
-	z-index: 100;
-	top: var(--margin);
-	outline: solid var(--margin) var(--background-color);
+	flex-direction: column;
+	gap: 8px;
+	padding: 10px;
 }
 
-.header-burger {
-	flex-shrink: 1;
-	width: 1.3em;
+.topbar {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	padding: 2px 2px 6px;
 }
 
-/**
- * HIDE MESSAGE
- */
+.topbar h1 {
+	font-size: 1.2rem;
+	line-height: 1.1;
+}
+
+.topbar p {
+	margin-top: 3px;
+	color: var(--muted);
+	font-size: 0.82rem;
+}
+
+.organize-toggle,
+.clear-search,
+.status-tabs button,
+.folder-strip button,
+.bulk-actions button,
+.folder-form button {
+	min-height: 30px;
+	padding: 0 10px;
+	border: 1px solid var(--line);
+	background: var(--panel);
+	color: var(--muted);
+	font-weight: 700;
+}
+
+.organize-toggle.active,
+.status-tabs button.active,
+.folder-strip button.active {
+	border-color: color-mix(in srgb, var(--accent) 55%, var(--line));
+	background: var(--accent-soft);
+	color: var(--accent);
+}
+
 .notice {
-	background: #8882;
-	margin: 0;
-	padding: 0.6em;
-	border-radius: 0.5em;
+	display: flex;
+	gap: 8px;
+	align-items: center;
+	justify-content: space-between;
+	padding: 7px 9px;
+	border: 1px solid var(--line-soft);
+	border-radius: 6px;
+	background: var(--panel);
+	color: var(--muted);
+	font-size: 0.78rem;
 }
 
 .hide-action {
-	border-bottom: 1px #2b2c2c dotted;
+	flex: 0 0 auto;
+	color: var(--accent);
+	font-weight: 700;
+	text-decoration: underline;
+	text-underline-offset: 3px;
 }
 
-/**
- * LIST
- */
-#ext-list {
-	margin: 0 calc(var(--margin) * -1);
+.control-panel {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	padding: 8px 0 10px;
+	border-block: 1px solid var(--line-soft);
+}
+
+.search-row {
+	display: flex;
+	gap: 6px;
+	align-items: center;
+}
+
+.search-box {
+	position: relative;
+	flex: 1 1 auto;
+	min-width: 0;
+}
+
+.search-label {
+	position: absolute;
+	inset-block-start: 50%;
+	inset-inline-start: 10px;
+	color: var(--muted);
+	font-size: 0.7rem;
+	font-weight: 800;
+	letter-spacing: 0.02em;
+	text-transform: uppercase;
+	transform: translateY(-50%);
+	pointer-events: none;
+}
+
+input[type='search'],
+.folder-form input,
+.folder-select {
+	width: 100%;
+	height: 34px;
+	border: 1px solid var(--line);
+	border-radius: 6px;
+	outline: 0;
+	background: var(--panel);
+	color: var(--text);
+}
+
+input[type='search'] {
+	padding: 0 10px 0 68px;
+}
+
+.folder-form input {
+	min-width: 0;
+	padding: 0 9px;
+}
+
+input:focus,
+select:focus {
+	border-color: var(--accent);
+	box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.status-tabs,
+.folder-strip,
+.bulk-actions {
+	display: flex;
+	gap: 6px;
+}
+
+.status-tabs button,
+.folder-strip button {
+	flex: 0 0 auto;
+	justify-content: space-between;
+}
+
+.status-tabs button {
+	flex: 1 1 0;
+	min-width: 0;
+}
+
+.folder-strip {
+	overflow-x: auto;
+	padding-bottom: 2px;
+	scrollbar-width: thin;
+}
+
+.folder-strip button span {
+	max-width: 130px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.status-tabs small,
+.folder-strip small,
+.section-heading span {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-width: 20px;
+	height: 20px;
+	padding: 0 6px;
+	border-radius: 999px;
+	background: color-mix(in srgb, var(--muted) 14%, transparent);
+	color: var(--muted);
+	font-size: 0.72rem;
+	font-weight: 800;
+}
+
+.organize-panel {
+	display: grid;
+	gap: 7px;
+	padding-top: 2px;
+}
+
+.folder-form {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) auto;
+	gap: 6px;
+}
+
+.bulk-actions {
+	flex-wrap: wrap;
+}
+
+.bulk-actions button.danger {
+	border-color: color-mix(in srgb, var(--danger) 38%, var(--line));
+	background: var(--danger-soft);
+	color: var(--danger);
+}
+
+.extension-groups {
+	display: flex;
+	flex-direction: column;
+	gap: 7px;
+}
+
+.section-heading {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 4px 2px 0;
+	color: var(--muted);
+}
+
+.section-heading h2 {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-size: 0.76rem;
+	font-weight: 800;
+	letter-spacing: 0.02em;
+	text-transform: uppercase;
+}
+
+.ext-list {
+	margin: 0;
 	padding: 0;
+	border-block-start: 1px solid var(--line-soft);
 	list-style: none;
 }
 
 .ext {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) auto;
+	gap: 8px;
+	align-items: center;
+	min-height: 50px;
+	padding: 7px 2px;
+	border-block-end: 1px solid var(--line-soft);
+}
+
+.ext:hover,
+.keyboard-navigation .ext:focus-within {
+	background: color-mix(in srgb, var(--panel-muted) 45%, transparent);
+}
+
+.ext.disabled .ext-copy,
+.ext.disabled .ext-icon img {
+	filter: grayscale(70%);
+	opacity: 0.55;
+}
+
+.ext.busy {
+	opacity: 0.72;
+}
+
+.ext-main {
+	justify-content: flex-start;
+	min-width: 0;
+	min-height: 38px;
+	padding: 2px;
+	text-align: start;
+}
+
+.ext-main:hover:not(:disabled),
+.keyboard-navigation .ext-main:focus-visible {
+	background: color-mix(in srgb, var(--panel-muted) 65%, transparent);
+	box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 10%, transparent);
+}
+
+.ext-icon {
+	display: inline-flex;
+	flex: 0 0 30px;
+	align-items: center;
+	justify-content: center;
+	width: 30px;
+	height: 30px;
+	border-radius: 6px;
+	background: var(--panel-muted);
+}
+
+.ext-icon img {
+	width: 20px;
+	height: 20px;
+	object-fit: contain;
+}
+
+.ext-copy {
+	display: grid;
+	gap: 3px;
+	min-width: 0;
+}
+
+.ext-title-row,
+.ext-meta {
 	display: flex;
-	flex-wrap: wrap;
-	white-space: nowrap;
-	font-size: 1.2em;
-	line-height: 1.9;
+	align-items: center;
+	min-width: 0;
 }
 
-.ext:not(:last-child) {
-	border-bottom: 1px solid #8883;
-}
-
-.ext.type-development {
-	color: var(--development-color);
-}
-
-.ext.type-admin {
-	color: var(--admin-color);
-}
-
-/* Separate pinned extensions from the rest. Don't apply if they're *all* pinned */
-.ext.pinned:nth-last-child(1 of .pinned).ext:not(:last-child) {
-	border-bottom-width: 5px;
+.ext-title-row {
+	gap: 5px;
 }
 
 .ext-name {
-	flex-grow: 1;
+	min-width: 0;
 	overflow: hidden;
 	text-overflow: ellipsis;
-	font-weight: bold;
-	position: relative;
+	white-space: nowrap;
+	font-weight: 760;
 }
 
-.disabled .ext-name {
-	font-weight: normal;
-	filter: grayscale(60%);
-	opacity: 50%;
+.ext-pill {
+	flex: 0 0 auto;
+	max-width: 92px;
+	overflow: hidden;
+	padding: 1px 5px;
+	border-radius: 999px;
+	background: var(--accent-soft);
+	color: var(--accent);
+	font-size: 0.66rem;
+	font-weight: 800;
+	text-overflow: ellipsis;
+	text-transform: uppercase;
+	white-space: nowrap;
 }
 
-.ext img {
-	width: 16px;
-	height: 16px;
-	vertical-align: -3px;
+.ext-pill.folder {
+	background: var(--panel-muted);
+	color: var(--muted);
 }
 
-.ext-name img {
-	padding: 0 var(--margin);
+.ext-pill.dev {
+	background: #eaf0ff;
+	color: #315db5;
+}
+
+.ext-pill.admin {
+	background: var(--danger-soft);
+	color: var(--danger);
+}
+
+.ext-meta {
+	gap: 5px;
+	overflow: hidden;
+	color: var(--muted);
+	font-size: 0.76rem;
+	white-space: nowrap;
+}
+
+.ext-meta span:last-child {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.status-dot {
+	width: 7px;
+	height: 7px;
+	border-radius: 50%;
+	background: var(--muted);
+}
+
+.status-dot.enabled {
+	background: var(--success);
+}
+
+.meta-divider {
+	color: color-mix(in srgb, var(--muted) 50%, transparent);
+}
+
+.ext-actions {
+	display: flex;
+	flex: 0 0 auto;
+	gap: 5px;
+	align-items: center;
+	justify-content: end;
+}
+
+.folder-select {
+	width: 132px;
+	padding: 0 8px;
+	color: var(--muted);
+	font-size: 0.78rem;
+	font-weight: 700;
+}
+
+.mini-action,
+.icon-action {
+	min-height: 28px;
+	border: 1px solid var(--line);
+	background: var(--panel);
+	color: var(--muted);
+	font-size: 0.75rem;
+	font-weight: 800;
+}
+
+.mini-action {
+	padding: 0 8px;
+}
+
+.mini-action.primary {
+	border-color: color-mix(in srgb, var(--accent) 42%, var(--line));
+	background: var(--accent-soft);
+	color: var(--accent);
+}
+
+.mini-action.active {
+	border-color: color-mix(in srgb, var(--success) 42%, var(--line));
+	color: var(--success);
+}
+
+.mini-action.danger {
+	color: var(--danger);
+}
+
+.remove-action {
+	width: 62px;
+}
+
+.remove-action.armed {
+	border-color: color-mix(in srgb, var(--danger) 56%, var(--line));
+	background: var(--danger-soft);
+	color: var(--danger);
+}
+
+.icon-action {
+	width: 28px;
+}
+
+.icon-action img {
+	width: 15px;
+	height: 15px;
+}
+
+.mini-action.danger:hover:not(:disabled),
+.icon-action.danger:hover:not(:disabled) {
+	border-color: color-mix(in srgb, var(--danger) 46%, var(--line));
+	background: var(--danger-soft);
+	color: var(--danger);
+}
+
+.mini-action:hover:not(:disabled),
+.icon-action:hover:not(:disabled),
+.organize-toggle:hover:not(:disabled),
+.clear-search:hover:not(:disabled),
+.status-tabs button:hover:not(:disabled),
+.folder-strip button:hover:not(:disabled),
+.bulk-actions button:hover:not(:disabled),
+.folder-form button:hover:not(:disabled) {
+	border-color: color-mix(in srgb, var(--accent) 45%, var(--line));
+	background: color-mix(in srgb, var(--accent-soft) 65%, var(--panel));
+	color: var(--accent);
 }
 
 .ext-toggle {
-	--switch-width: 2.2em;
-	--switch-height: 1.2em;
-	--switch-padding: 0.13em;
-	align-self: center;
+	--switch-width: 38px;
+	--switch-height: 22px;
+	--switch-padding: 3px;
 	box-sizing: border-box;
 	inline-size: var(--switch-width);
 	block-size: var(--switch-height);
-	margin-inline: 0.35em;
 	padding: var(--switch-padding);
+	border: 1px solid color-mix(in srgb, var(--muted) 24%, transparent);
 	border-radius: 999px;
-	background: #8b949e;
-	opacity: 100%;
-	transition:
-		background-color 120ms ease,
-		opacity 120ms ease;
+	background: #98a2b3;
 }
 
 .ext-toggle.enabled {
-	background: #237a43;
-}
-
-.ext-toggle:disabled {
-	cursor: not-allowed;
-	opacity: 45%;
-}
-
-.ext-toggle:hover:not(:disabled),
-.keyboard-navigation .ext-toggle:focus-visible {
-	background: #6b7280;
-}
-
-.ext-toggle.enabled:hover:not(:disabled),
-.keyboard-navigation .ext-toggle.enabled:focus-visible {
-	background: #2f9958;
+	border-color: color-mix(in srgb, var(--success) 62%, transparent);
+	background: var(--success);
 }
 
 .ext-toggle-knob {
@@ -193,8 +556,8 @@ button:hover,
 	inline-size: calc(var(--switch-height) - var(--switch-padding) * 2);
 	block-size: calc(var(--switch-height) - var(--switch-padding) * 2);
 	border-radius: 50%;
-	background: white;
-	box-shadow: 0 1px 2px #0005;
+	background: #fff;
+	box-shadow: 0 1px 3px #10182842;
 	transform: translateX(0);
 	transition: transform 120ms ease;
 }
@@ -203,50 +566,76 @@ button:hover,
 	transform: translateX(calc(var(--switch-width) - var(--switch-height)));
 }
 
-.ext > :not(.ext-name) {
-	padding-inline: 0.3em;
-	opacity: 20%;
-	flex-shrink: 0;
-}
-
-.ext > .ext-toggle {
-	padding: var(--switch-padding);
-	opacity: 100%;
-}
-
-.ext > :last-child:not(.ext-name) {
-	/* Adjust the padding of the right-most columm to optically align the icons with the burger */
-	padding-inline: calc(var(--margin) + 1px);
-}
-
 .ext-error {
-	flex-basis: 100%;
-	margin: -0.2em var(--margin) 0.4em calc(16px + var(--margin) * 2);
-	white-space: normal;
-	color: #a40000;
-	font-size: 0.75em;
-	line-height: 1.35;
+	grid-column: 1 / -1;
+	margin: 0 2px 2px 35px;
+	padding: 7px 8px;
+	border: 1px solid color-mix(in srgb, var(--danger) 32%, var(--line));
+	border-radius: 6px;
+	background: var(--danger-soft);
+	color: var(--danger);
+	font-size: 0.76rem;
 }
 
-/* Don't use .ext:hover https://github.com/hankxdev/one-click-extensions-manager/pull/109 */
-.ext:has(:hover) > *,
-.keyboard-navigation .ext:focus-within > * {
-	opacity: 100%;
+.empty-state {
+	padding: 26px 12px;
+	border: 1px dashed var(--line);
+	border-radius: 6px;
+	background: var(--panel);
+	text-align: center;
+}
+
+.empty-state h2 {
+	font-size: 0.95rem;
+}
+
+.empty-state p {
+	margin-top: 5px;
+	color: var(--muted);
+}
+
+@media (max-width: 430px) {
+	html,
+	body {
+		min-width: 340px;
+	}
+
+	.app-shell {
+		padding: 8px;
+	}
+
+	.ext {
+		grid-template-columns: 1fr;
+	}
+
+	.ext-actions {
+		justify-content: space-between;
+		padding-inline-start: 34px;
+	}
+
+	.folder-select {
+		width: min(220px, 100%);
+	}
 }
 
 @media (prefers-color-scheme: dark) {
-	body {
-		color: #e8eaed;
-		--development-color: #83acf5;
-		--admin-color: #ffa38d;
-		--hover-color: #c4d7dc38;
+	:root {
+		--surface: #181b21;
+		--panel: #20242c;
+		--panel-muted: #2a2f39;
+		--line: #3d4450;
+		--line-soft: #303743;
+		--text: #f2f4f7;
+		--muted: #a5adbb;
+		--accent: #84a7ff;
+		--accent-soft: #263550;
+		--success: #4fc47f;
+		--danger: #ff7c73;
+		--danger-soft: #482826;
 	}
 
-	.ext :not(.ext-name) img {
-		filter: brightness(1.6);
-	}
-
-	.ext-error {
-		color: #ff9d9d;
+	.ext-icon img,
+	.icon-action img {
+		filter: brightness(1.08);
 	}
 }

--- a/source/style.css
+++ b/source/style.css
@@ -95,6 +95,36 @@ p {
 	padding: 2px 2px 6px;
 }
 
+.brand-block {
+	display: flex;
+	min-width: 0;
+	gap: 9px;
+	align-items: center;
+}
+
+.brand-logo {
+	flex: 0 0 auto;
+	width: 34px;
+	height: 34px;
+	border-radius: 8px;
+	box-shadow: 0 1px 3px #1018281f;
+}
+
+.brand-block > div {
+	min-width: 0;
+}
+
+.brand-label {
+	overflow: hidden;
+	color: var(--accent);
+	font-size: 0.68rem;
+	font-weight: 850;
+	letter-spacing: 0.06em;
+	text-overflow: ellipsis;
+	text-transform: uppercase;
+	white-space: nowrap;
+}
+
 .topbar h1 {
 	font-size: 1.2rem;
 	line-height: 1.1;

--- a/source/style.css
+++ b/source/style.css
@@ -151,10 +151,67 @@ button:hover,
 	padding: 0 var(--margin);
 }
 
+.ext-toggle {
+	--switch-width: 2.2em;
+	--switch-height: 1.2em;
+	--switch-padding: 0.13em;
+	align-self: center;
+	box-sizing: border-box;
+	inline-size: var(--switch-width);
+	block-size: var(--switch-height);
+	margin-inline: 0.35em;
+	padding: var(--switch-padding);
+	border-radius: 999px;
+	background: #8b949e;
+	opacity: 100%;
+	transition:
+		background-color 120ms ease,
+		opacity 120ms ease;
+}
+
+.ext-toggle.enabled {
+	background: #237a43;
+}
+
+.ext-toggle:disabled {
+	cursor: not-allowed;
+	opacity: 45%;
+}
+
+.ext-toggle:hover:not(:disabled),
+.keyboard-navigation .ext-toggle:focus-visible {
+	background: #6b7280;
+}
+
+.ext-toggle.enabled:hover:not(:disabled),
+.keyboard-navigation .ext-toggle.enabled:focus-visible {
+	background: #2f9958;
+}
+
+.ext-toggle-knob {
+	display: block;
+	inline-size: calc(var(--switch-height) - var(--switch-padding) * 2);
+	block-size: calc(var(--switch-height) - var(--switch-padding) * 2);
+	border-radius: 50%;
+	background: white;
+	box-shadow: 0 1px 2px #0005;
+	transform: translateX(0);
+	transition: transform 120ms ease;
+}
+
+.ext-toggle.enabled .ext-toggle-knob {
+	transform: translateX(calc(var(--switch-width) - var(--switch-height)));
+}
+
 .ext > :not(.ext-name) {
 	padding-inline: 0.3em;
 	opacity: 20%;
 	flex-shrink: 0;
+}
+
+.ext > .ext-toggle {
+	padding: var(--switch-padding);
+	opacity: 100%;
 }
 
 .ext > :last-child:not(.ext-name) {

--- a/source/style.css
+++ b/source/style.css
@@ -104,6 +104,7 @@ button:hover,
 
 .ext {
 	display: flex;
+	flex-wrap: wrap;
 	white-space: nowrap;
 	font-size: 1.2em;
 	line-height: 1.9;
@@ -161,6 +162,15 @@ button:hover,
 	padding-inline: calc(var(--margin) + 1px);
 }
 
+.ext-error {
+	flex-basis: 100%;
+	margin: -0.2em var(--margin) 0.4em calc(16px + var(--margin) * 2);
+	white-space: normal;
+	color: #a40000;
+	font-size: 0.75em;
+	line-height: 1.35;
+}
+
 /* Don't use .ext:hover https://github.com/hankxdev/one-click-extensions-manager/pull/109 */
 .ext:has(:hover) > *,
 .keyboard-navigation .ext:focus-within > * {
@@ -177,5 +187,9 @@ button:hover,
 
 	.ext :not(.ext-name) img {
 		filter: brightness(1.6);
+	}
+
+	.ext-error {
+		color: #ff9d9d;
 	}
 }

--- a/source/style.css
+++ b/source/style.css
@@ -107,6 +107,7 @@ p {
 }
 
 .organize-toggle,
+.panel-summary,
 .clear-search,
 .status-tabs button,
 .folder-strip button,
@@ -152,9 +153,58 @@ p {
 .control-panel {
 	display: flex;
 	flex-direction: column;
-	gap: 8px;
-	padding: 8px 0 10px;
+	gap: 6px;
+	padding: 6px 0;
 	border-block: 1px solid var(--line-soft);
+}
+
+.panel-summary {
+	justify-content: space-between;
+	min-height: 34px;
+	padding-inline: 10px;
+	text-align: start;
+}
+
+.panel-summary span:first-child {
+	display: inline-flex;
+	min-width: 0;
+	gap: 8px;
+	align-items: baseline;
+}
+
+.panel-summary strong {
+	overflow: hidden;
+	color: var(--text);
+	font-size: 0.82rem;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.panel-summary small {
+	color: var(--muted);
+	font-size: 0.74rem;
+	font-weight: 800;
+}
+
+.dropdown-arrow {
+	width: 8px;
+	height: 8px;
+	margin-inline: 4px 2px;
+	border-block-end: 2px solid currentColor;
+	border-inline-end: 2px solid currentColor;
+	transform: rotate(45deg);
+	transition: transform 140ms ease;
+}
+
+.panel-summary[aria-expanded='true'] .dropdown-arrow {
+	transform: rotate(225deg);
+}
+
+.control-panel-body {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	padding-top: 2px;
 }
 
 .search-row {
@@ -523,6 +573,7 @@ select:focus {
 .mini-action:hover:not(:disabled),
 .icon-action:hover:not(:disabled),
 .organize-toggle:hover:not(:disabled),
+.panel-summary:hover:not(:disabled),
 .clear-search:hover:not(:disabled),
 .status-tabs button:hover:not(:disabled),
 .folder-strip button:hover:not(:disabled),


### PR DESCRIPTION
## Summary

This PR adds a native helper system and significant UI/UX improvements to the extension manager:

### Native helper (`native-helper/`)
- Cross-platform native host (`native-host.mjs`) with macOS/Windows install scripts
- Native clicker (`native-clicker.m`) for opening extension popups without `osascript`
- HTTP host bridge for extension popup management
- Diagnostic scripts for macOS and Windows
- Tests for native host functionality

### Extension popup management
- Open extension popups directly from the manager
- Force toolbar action to native popup (removes popup page fallback)
- Keep unpinned extension menu lookup bounded
- Open unpinned targets from manager popup
- Avoid recurring accessibility prompts

### UI improvements
- Add folder grouping and uninstall controls
- Collapse extension controls for cleaner layout
- Cross-platform OnFire setup support
- Updated options page (dropdown → radios, full name option)
- Significant style.css expansion (+757 lines)
- Updated translations (de, en, es, fr, he, it, ja, ko, lv, nl, pl, ru, tr, zh_CN, zh_TW)

### Other
- Fix fork extension identity
- Fix native host pipe reads
- Harden popup helper and add extension switches
- Updated CI/release workflows

## Test plan
- `npm test` → 23 pass, 0 fail
- `npm run lint` → clean
- `npm run build` → builds successfully
- Manual: extension popups open from manager, folder grouping works, uninstall works